### PR TITLE
Final update for 3.10

### DIFF
--- a/CVAD_Inventory_V3_ReadMe.rtf
+++ b/CVAD_Inventory_V3_ReadMe.rtf
@@ -80,26 +80,26 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }
 {\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname 
 ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid225408
-\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1575696\rsid1654655\rsid1857973\rsid2054605\rsid2195246\rsid2243781\rsid2517006\rsid2579094\rsid2584542\rsid2653562\rsid2902416\rsid2978753\rsid3097678
-\rsid3300860\rsid3430394\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4138244\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4462158\rsid4522193\rsid4740061\rsid4745200\rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5207971\rsid5209339
-\rsid5267713\rsid5703879\rsid5847035\rsid6053627\rsid6054960\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6635878\rsid6637724\rsid6947370\rsid6966385\rsid7432229\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782
-\rsid8596828\rsid8662784\rsid8790405\rsid8876191\rsid9047498\rsid9112866\rsid9338186\rsid9376723\rsid9520485\rsid9532820\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10578344\rsid10580546
-\rsid10900280\rsid10963467\rsid11041950\rsid11227030\rsid11488686\rsid11605034\rsid11823514\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708
-\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13853169\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14577313\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid15428007\rsid15613047
-\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16017241\rsid16017738\rsid16154053\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420
-\rsid16597410\rsid16671705}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2020\mo9\dy10\hr14\min53}{\version101}{\edmins11893}{\nofpages29}{\nofwords8686}{\nofchars49511}{\nofcharsws58081}{\vern7}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1575696\rsid1654655\rsid1857973\rsid2054605\rsid2191181\rsid2195246\rsid2243781\rsid2517006\rsid2579094\rsid2584542\rsid2653562\rsid2902416\rsid2978753
+\rsid3097678\rsid3300860\rsid3430394\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4138244\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4462158\rsid4522193\rsid4740061\rsid4745200\rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5207971
+\rsid5209339\rsid5267713\rsid5703879\rsid5847035\rsid6053627\rsid6054960\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6635878\rsid6637724\rsid6947370\rsid6966385\rsid7432229\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203
+\rsid8410782\rsid8596828\rsid8662784\rsid8790405\rsid8876191\rsid9047498\rsid9112866\rsid9338186\rsid9376723\rsid9520485\rsid9532820\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10578344
+\rsid10580546\rsid10900280\rsid10963467\rsid10967884\rsid11041950\rsid11227030\rsid11488686\rsid11605034\rsid11823514\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757
+\rsid12863195\rsid12978708\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13853169\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14577313\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568
+\rsid15405088\rsid15428007\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16017241\rsid16017738\rsid16154053\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917
+\rsid16473260\rsid16517051\rsid16527420\rsid16597410\rsid16671705\rsid16713983}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo10\dy1\hr6\min52}{\version103}{\edmins11902}{\nofpages29}{\nofwords8713}{\nofchars49669}{\nofcharsws58266}{\vern9}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBYZmtQCU4eSzLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2195246 \chftnsep 
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBYYWtQAazGctLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2191181 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2195246 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2191181 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2195246 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2191181 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2195246 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2191181 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid16203271 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 
@@ -133,12 +133,11 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Portuguese
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Spanish
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Swedish
-\par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid9112866 
-\hich\af43\dbch\af31505\loch\f43 Prerequisites
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Before we can start using PowerShell to document anything in a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16154053 \hich\af37\dbch\af31505\loch\f37 
-Citrix Virtual Apps and Desktops (CVAD) }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Site, let us ensure we have the necessary requirements.
+\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15405088 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \hich\af43\dbch\af31505\loch\f43 Prerequisites
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
+Before we can start using PowerShell to document anything in a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16154053 \hich\af37\dbch\af31505\loch\f37 Citrix Virtual Apps and Desktops (CVAD) }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Site, let us ensure we have the necessary requirements.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 If the script will be run remotely, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 there are two choices: install }{\rtlch\fcs1 
@@ -209,11 +208,11 @@ PVS PowerShell SDK x??
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d000000009f009133000002000000000000}}}{\fldrslt {\rtlch\fcs1 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d000000009f0091330000020000000000004500}}}{\fldrslt {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
-\hich\af37\dbch\af31505\loch\f37 Save the file to your default download fo\hich\af37\dbch\af31505\loch\f37 lder.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\hich\af37\dbch\af31505\loch\f37 Save the file to your default download f\hich\af37\dbch\af31505\loch\f37 older.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 Extract the file to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 C:\\}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16154053 
 \hich\af37\dbch\af31505\loch\f37 CVADV3}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Script}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 
@@ -293,8 +292,8 @@ Script Usage
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8394203 \page \hich\af43\dbch\af31505\loch\f43 Help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
 \par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8876191 
-\par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16154053 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 \hich\af2\dbch\af31505\loch\f2 C:\\Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \\\hich\af2\dbch\af31505\loch\f2 
+\par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15405088 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \\\hich\af2\dbch\af31505\loch\f2 
 CVAD_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
@@ -302,51 +301,48 @@ CVAD_Inventory_V3.ps1
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 \hich\af2\dbch\af31505\loch\f2 C:\\Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \\\hich\af2\dbch\af31505\loch\f2 
-CVAD_Inventory_V3.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-AdminAddress <String>] [-Administrators] [-Applications] [-BrokerRegistr\hich\af2\dbch\af31505\loch\f2 
-yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-Controllers] }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-CSV] [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs\hich\af2\dbch\af31505\loch\f2 ] 
-}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-MaxDetails] [-NoADPolicies] [-NoPolicies] [-NoSessions] [-Policies] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-StartDate <DateTime>] [-StoreFront] [-UserName <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 [-VDARegistryKeys] [-SmtpServer <String>] [-SmtpPort}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid16154053 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 <Int32>] [-UseSSL] [-Fr\hich\af2\dbch\af31505\loch\f2 om }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 <String>] [-To <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \\\hich\af2\dbch\af31505\loch\f2 
+CVAD_Inventory_V3.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 [-AdminAddress <String>] [-Administrators] [-Applications] [-BrokerRegistryKeys\hich\af2\dbch\af31505\loch\f2 
+] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2     [-Controllers] [-CSV] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-Fold\hich\af2\dbch\af31505\loch\f2 er <String>] [-Hardware] [-Hosting] [-Log] [-Logging] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-MaxDetails] [-NoADPolicies] [-NoPolicies] [-NoSessions] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 [-Policies] [-ScriptInfo] [-Section <String>] [-StartDate <DateTime>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2     [-StoreFront] [-UserName <String>] [-VDARegistryKey\hich\af2\dbch\af31505\loch\f2 s] [-SmtpServer <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix Virtual Apps and Desktops (CVAD) 2006 or later Site }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 sing}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 Microsoft PowerShell, Word, plain text, or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix Virtual Apps and Desktops (CVAD) 2006 or later Site
+\par \hich\af2\dbch\af31505\loch\f2     using Microsoft PowerShell, Word, plain \hich\af2\dbch\af31505\loch\f2 text, or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This Script requires at least Powe\hich\af2\dbch\af31505\loch\f2 rShell version 5.
+\par \hich\af2\dbch\af31505\loch\f2     This Script requires at least PowerShell version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Default output is now HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the \hich\f2 \endash \loch\f2 AdminAddress (AA) parameter.
+\par \hich\af2\dbch\af31505\loch\f2     You can run this script remot\hich\af2\dbch\af31505\loch\f2 ely using the \hich\f2 \endash \loch\f2 AdminAddress (AA) parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This \hich\af2\dbch\af31505\loch\f2 script supports versions of CVAD starting with 2006.
+\par \hich\af2\dbch\af31505\loch\f2     This script supports versions of CVAD starting with 2006.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have at least Read access to the SQL
 \par \hich\af2\dbch\af31505\loch\f2     Server(s) that hold(s) the Citrix Site, Monitoring, and Logging databases.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary\hich\af2\dbch\af31505\loch\f2  information for:
+\par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
-\par \hich\af2\dbch\af31505\loch\f2         App-V Publishing
+\par \hich\af2\dbch\af31505\loch\f2         App-V\hich\af2\dbch\af31505\loch\f2  Publishing
 \par \hich\af2\dbch\af31505\loch\f2         Application Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Controllers
@@ -358,30 +354,32 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2         Zones
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
+\par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown\hich\af2\dbch\af31505\loch\f2  in the top half of Citrix Studio for:
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Controllers
-\par \hich\af2\dbch\af31505\loch\f2         Administ\hich\af2\dbch\af31505\loch\f2 rators
+\par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs param\hich\af2\dbch\af31505\loch\f2 eter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take\hich\af2\dbch\af31505\loch\f2  a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
-\par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     take an extremely \hich\af2\dbch\af31505\loch\f2 long time to complete and generate an exceptionally long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Using BrokerRegistryKeys requires the script is run elevated.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the CVAD Site.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the follo\hich\af2\dbch\af31505\loch\f2 wing language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents a\hich\af2\dbch\af31505\loch\f2 nd Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
@@ -392,47 +390,37 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
-\par \hich\af2\dbch\af31505\loch\f2         Spanish
+\par \hich\af2\dbch\af31505\loch\f2         S\hich\af2\dbch\af31505\loch\f2 panish
 \par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
-\par \hich\af2\dbch\af31505\loch\f2     -HTML\hich\af2\dbch\af31505\loch\f2  [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an.html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value         \hich\af2\dbch\af31505\loch\f2        False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead \hich\af2\dbch\af31505\loch\f2 of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X\hich\af2\dbch\af31505\loch\f2  to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Cre\hich\af2\dbch\af31505\loch\f2 ates a formatted text file with a .txt extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -440,22 +428,32 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a.txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled b\hich\af2\dbch\af31505\loch\f2 y default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchPar\hich\af2\dbch\af31505\loch\f2 ameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2         The timestamp is in th\hich\af2\dbch\af31505\loch\f2 e format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or.pdf).
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the add\hich\af2\dbch\af31505\loch\f2 ress of a XenDesktop controller the PowerShell snapins will connect
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a CVAD controller the PowerShell snapins will connect
 \par \hich\af2\dbch\af31505\loch\f2         to.
 \par \hich\af2\dbch\af31505\loch\f2         This can be provided as a hostname or an IP address.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to Localhost.
@@ -463,52 +461,54 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Localhost
+\par \hich\af2\dbch\af31505\loch\f2         Default val\hich\af2\dbch\af31505\loch\f2 ue                Localhost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParamete\hich\af2\dbch\af31505\loch\f2 r>]
+\par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Administrator Scopes and Roles.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disab\hich\af2\dbch\af31505\loch\f2 led by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Admins.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildc\hich\af2\dbch\af31505\loch\f2 ard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabl\hich\af2\dbch\af31505\loch\f2 ed by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard\hich\af2\dbch\af31505\loch\f2  characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller section.
+\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registr\hich\af2\dbch\af31505\loch\f2 y keys to the Controller section.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         *****Requires the script is run elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
 \par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controller, to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BR\hich\af2\dbch\af31505\loch\f2 K.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Banded \hich\af2\dbch\af31505\loch\f2 (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
@@ -518,8 +518,8 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -530,24 +530,24 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field\hich\af2\dbch\af31505\loch\f2 :
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a \hich\af2\dbch\af31505\loch\f2 Fax field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
@@ -559,19 +559,19 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the\hich\af2\dbch\af31505\loch\f2  Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserI\hich\af2\dbch\af31505\loch\f2 nfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter h\hich\af2\dbch\af31505\loch\f2 as an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeli\hich\af2\dbch\af31505\loch\f2 ne input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
@@ -579,105 +579,84 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Defau\hich\af2\dbch\af31505\loch\f2 lt value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
-\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page \hich\af2\dbch\af31505\loch\f2 to use.
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
-\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word\hich\af2\dbch\af31505\loch\f2  en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Austere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
-\par \hich\af2\dbch\af31505\loch\f2               \hich\af2\dbch\af31505\loch\f2   Banded (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works\hich\af2\dbch\af31505\loch\f2 )
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wo\hich\af2\dbch\af31505\loch\f2 rd 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 m\hich\af2\dbch\af31505\loch\f2 anually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or fon\hich\af2\dbch\af31505\loch\f2 t changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word \hich\af2\dbch\af31505\loch\f2 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/20\hich\af2\dbch\af31505\loch\f2 16. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Ligh\hich\af2\dbch\af31505\loch\f2 t) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            Whisp (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (W\hich\af2\dbch\af31505\loch\f2 ord 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Controllers [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Lists the following information to the Controllers section:
+\par \hich\af2\dbch\af31505\loch\f2         Lists the follow\hich\af2\dbch\af31505\loch\f2 ing information to the Controllers section:
 \par \hich\af2\dbch\af31505\loch\f2                 List of installed Microsoft Hotfixes and Updates
 \par \hich\af2\dbch\af31505\loch\f2                 List of Citrix installed components
 \par \hich\af2\dbch\af31505\loch\f2                 List of Windows installed Roles and Features
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Appendix C List of installed Microsoft Hotfixes and Updates for all
+\par \hich\af2\dbch\af31505\loch\f2                 Appendix C List of\hich\af2\dbch\af31505\loch\f2  installed Microsoft Hotfixes and Updates for all
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Appendix D List of Citrix installed components for all Controllers
-\par \hich\af2\dbch\af31505\loch\f2                 Appendix E List of Windows installed Roles and Features\hich\af2\dbch\af31505\loch\f2  for all Controllers
+\par \hich\af2\dbch\af31505\loch\f2                 Appendix E List of Windows installed Roles and Features for all Controllers
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DDC.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accep\hich\af2\dbch\af31505\loch\f2 t pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CSV [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Will create a CSV file for each Appendix.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is False.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Output CSV filename is in the format:
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_Appendix#_NameOfAppendix.csv
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         For example:
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_Append\hich\af2\dbch\af31505\loch\f2 ixB_ControllerRegistryItems.csv
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixE_Win\hich\af2\dbch\af31505\loch\f2 dowsInstalledComponents.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -685,34 +664,55 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Delive\hich\af2\dbch\af31505\loch\f2 ryGroups [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -CSV [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Will create a CSV file for each Appendix.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is False.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Ou\hich\af2\dbch\af31505\loch\f2 tput CSV filename is in the format:
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_Appendix#_NameOfAppendix.csv
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         For example:
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixB_Contro\hich\af2\dbch\af31505\loch\f2 llerRegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixE_WindowsInstal\hich\af2\dbch\af31505\loch\f2 ledComponents.csv
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information on all desktops in all Desktop (Delivery) Groups.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely lo\hich\af2\dbch\af31505\loch\f2 ng report.
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an e\hich\af2\dbch\af31505\loch\f2 xtremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
 \par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
 \par \hich\af2\dbch\af31505\loch\f2         long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by de\hich\af2\dbch\af31505\loch\f2 fault.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
 \par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This option i\hich\af2\dbch\af31505\loch\f2 s only available when the report is generated in Word and requires
+\par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is gene\hich\af2\dbch\af31505\loch\f2 rated in Word and requires
 \par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be locally installed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer re\hich\af2\dbch\af31505\loch\f2 port.
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
@@ -720,21 +720,21 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?     \hich\af2\dbch\af31505\loch\f2   false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer reque\hich\af2\dbch\af31505\loch\f2 sts more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -747,53 +747,54 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of\hich\af2\dbch\af31505\loch\f2  ED.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ED.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output fo\hich\af2\dbch\af31505\loch\f2 lder to save the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Ac\hich\af2\dbch\af31505\loch\f2 cept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParame\hich\af2\dbch\af31505\loch\f2 ter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 may require the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permissio\hich\af2\dbch\af31505\loch\f2 n to retrieve hardware information (i.e. Domain Admin
 \par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it t\hich\af2\dbch\af31505\loch\f2 akes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts, Host Connections, and Resources.
-\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts, Host Con\hich\af2\dbch\af31505\loch\f2 nections, and Resources.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
@@ -801,13 +802,33 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Logging [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous
-\par \hich\af2\dbch\af31505\loch\f2         seven days.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled b\hich\af2\dbch\af31505\loch\f2 y default.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     seven days.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         time to complete an\hich\af2\dbch\af31505\loch\f2 d can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -815,30 +836,11 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 time to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
-\par \hich\af2\dbch\af31505\loch\f2         long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
-\par \hich\af2\dbch\af31505\loch\f2                 Administrators
+\par \hich\af2\dbch\af31505\loch\f2                 Administrator\hich\af2\dbch\af31505\loch\f2 s
 \par \hich\af2\dbch\af31505\loch\f2                 Applications
 \par \hich\af2\dbch\af31505\loch\f2                 BrokerRegistryKeys
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
@@ -848,14 +850,16 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
 \par \hich\af2\dbch\af31505\loch\f2                 MachineCatalogs
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              StoreFront
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                StoreFront
 \par \hich\af2\dbch\af31505\loch\f2                 VDARegistryKeys
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         *****Requires the script is run elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoADPolicies.
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoSessions.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
-\par \hich\af2\dbch\af31505\loch\f2         can take a \hich\af2\dbch\af31505\loch\f2 very long time to run.
+\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can\hich\af2\dbch\af31505\loch\f2  create an extremely large report and
+\par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
@@ -863,17 +867,17 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information from the output document.
-\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Includes only Site policies created in Studio.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This Switch is useful in large AD environments, where there may be thousands
 \par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter has an alias of NoAD.
+\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter has an alias of NoAD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -881,22 +885,22 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -NoPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -NoPol\hich\af2\dbch\af31505\loch\f2 icies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD-based policy information from the output document.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by \hich\af2\dbch\af31505\loch\f2 default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?           \hich\af2\dbch\af31505\loch\f2          named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charact\hich\af2\dbch\af31505\loch\f2 ers?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoSessions [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes Machine Catalog, Application and Hosting session data from the report.
+\par \hich\af2\dbch\af31505\loch\f2         Excludes Machine Catalog, Application and Hosting session data from\hich\af2\dbch\af31505\loch\f2  the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the MaxDetails parameter does not change this setting.
 \par 
@@ -904,28 +908,23 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NS.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value                False
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the Poli\hich\af2\dbch\af31505\loch\f2 cies parameter can cause the report to take a very long time
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Using the Policies parameter can cause the report to take a very long time
 \par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Note: The Citrix Group Policy PowerShell module will not load from an elevated
-\par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
-\par \hich\af2\dbch\af31505\loch\f2         If the m\hich\af2\dbch\af31505\loch\f2 odule is manually imported, the module is not detected from an elevated
-\par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies, and NoADPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is\hich\af2\dbch\af31505\loch\f2  given to NoPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an a\hich\af2\dbch\af31505\loch\f2 lias of Pol.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -933,16 +932,16 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchPa\hich\af2\dbch\af31505\loch\f2 rameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is plac\hich\af2\dbch\af31505\loch\f2 ed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value     \hich\af2\dbch\af31505\loch\f2            False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -950,10 +949,10 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Processes a specific section of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
-\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Apps (Applications and Application Group Details)
+\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications and Application Group Details)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
 \par \hich\af2\dbch\af31505\loch\f2                 Catalogs (Machine Catalogs)
-\par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Config (Configuration)
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Groups (Delivery Groups)
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
@@ -962,41 +961,41 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
 \par \hich\af2\dbch\af31505\loch\f2                 StoreFront
 \par \hich\af2\dbch\af31505\loch\f2                 Zones
-\par \hich\af2\dbch\af31505\loch\f2                 All
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           All
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Notes:
 \par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Logging Switch to True.
 \par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies Switch to True.
-\par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies Switch is used, the script will terminate.
+\par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies Sw\hich\af2\dbch\af31505\loch\f2 itch is used, the script will terminate.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?  \hich\af2\dbch\af31505\loch\f2                   false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2         The start date for the Conf\hich\af2\dbch\af31505\loch\f2 iguration Logging report.
+\par \hich\af2\dbch\af31505\loch\f2         The start date for the Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The format for date only is MM/DD/YYYY.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
-\par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
+\par \hich\af2\dbch\af31505\loch\f2         The double quotes a\hich\af2\dbch\af31505\loch\f2 re needed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date minus seven days.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDa\hich\af2\dbch\af31505\loch\f2 ys(-7))
+\par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint\hich\af2\dbch\af31505\loch\f2  date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StoreFront [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has a\hich\af2\dbch\af31505\loch\f2 n alias of SF.
+\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter has an alias of SF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1004,16 +1003,16 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Username to use for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     -UserNam\hich\af2\dbch\af31505\loch\f2 e <String>
+\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?     \hich\af2\dbch\af31505\loch\f2                false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -VDARegistryKeys [<SwitchParameter>]
@@ -1021,23 +1020,23 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If this parameter is used, MachineCatalogs is set to True.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter ha\hich\af2\dbch\af31505\loch\f2 s an alias of VRK.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of VRK.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <Str\hich\af2\dbch\af31505\loch\f2 ing>
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard char\hich\af2\dbch\af31505\loch\f2 acters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
@@ -1067,13 +1066,13 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -1081,13 +1080,16 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         Error\hich\af2\dbch\af31505\loch\f2 Action, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe object\hich\af2\dbch\af31505\loch\f2 s to this script.
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     None. You cannot pi\hich\af2\dbch\af31505\loch\f2 pe objects to this script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
@@ -1095,17 +1097,16 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: CVAD_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14294352 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.10
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6966385 \hich\af2\dbch\af31505\loch\f2 Septe\hich\af2\dbch\af31505\loch\f2 mber }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9905429 
-\hich\af2\dbch\af31505\loch\f2 11}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6966385 \hich\af2\dbch\af31505\loch\f2 , 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: October 1, 2020
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
-\par \hich\af2\dbch\af31505\loch\f2     The co\hich\af2\dbch\af31505\loch\f2 mputer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for\hich\af2\dbch\af31505\loch\f2  the AdminAddress.
 \par 
 \par 
 \par 
@@ -1115,14 +1116,14 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\C\hich\af2\dbch\af31505\loch\f2 ommon\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="C\hich\af2\dbch\af31505\loch\f2 arl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Ad\hich\af2\dbch\af31505\loch\f2 ministrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1131,7 +1132,7 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\P\hich\af2\dbch\af31505\loch\f2 SScript >.\\CVAD_Inventory_V3.ps1 -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
 \par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
@@ -1143,17 +1144,17 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     Will\hich\af2\dbch\af31505\loch\f2  use all default values and save the document as a PDF file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT\hich\af2\dbch\af31505\loch\f2 _USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the scrip\hich\af2\dbch\af31505\loch\f2 t for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1173,7 +1174,7 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Saves the document as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the scrip\hich\af2\dbch\af31505\loch\f2 t for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1183,7 +1184,7 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all machines in all Machine Catalogs.
-\par \hich\af2\dbch\af31505\loch\f2     The co\hich\af2\dbch\af31505\loch\f2 mputer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script fo\hich\af2\dbch\af31505\loch\f2 r the AdminAddress.
 \par 
 \par 
 \par 
@@ -1192,29 +1193,29 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all desktops in all Desktop (Delivery) }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 Groups.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all desktops in all Desktop (Delivery)
+\par \hich\af2\dbch\af31505\loch\f2     Groups.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CV\hich\af2\dbch\af31505\loch\f2 AD_Inventory_V3.ps1 -DeliveryGroupsUtilization -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroupsUtilization -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requires the use of MSWord or PDF.
+\par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requi\hich\af2\dbch\af31505\loch\f2 res the use of MSWord or PDF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with utilization details for all Desktop (Delivery) }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with utilization details for all Desktop (Delivery)
+\par \hich\af2\dbch\af31505\loch\f2     Groups.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Def\hich\af2\dbch\af31505\loch\f2 ault values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for th\hich\af2\dbch\af31505\loch\f2 e Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1224,16 +1225,16 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroupsUtilization -PDF
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 \hich\af2\dbch\af31505\loch\f2 -DeliveryGroupsUtilization -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requires the use of MSWord or PDF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with u\hich\af2\dbch\af31505\loch\f2 tilization details for all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with utilization details for all Desktop (Delivery) Groups.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 y="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1244,13 +1245,13 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------------------\hich\af2\dbch\af31505\loch\f2 ---- EXAMPLE 11 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups -MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2     PS C\hich\af2\dbch\af31505\loch\f2 :\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all machines in all Machine Catalogs and
 \par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddres\hich\af2\dbch\af31505\loch\f2 s.
 \par 
 \par 
 \par 
@@ -1260,7 +1261,7 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Applications
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all applications.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddr\hich\af2\dbch\af31505\loch\f2 ess.
 \par 
 \par 
 \par 
@@ -1280,27 +1281,27 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -NoPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with no Policy information.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The comp\hich\af2\dbch\af31505\loch\f2 uter running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 15 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with no Citrix AD based Policy information.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Th\hich\af2\dbch\af31505\loch\f2 e computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 16 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Policies -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on Site policies created in Studio but
-\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy informati\hich\af2\dbch\af31505\loch\f2 on.
+\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1312,51 +1313,52 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Administrators
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on Administrator Scopes and Roles.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for th\hich\af2\dbch\af31505\loch\f2 e AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 \hich\af2\dbch\af31505\loch\f2 -Logging -StartDate 09/01/2020 -EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 09/30/2020
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Logging -StartDate 09/01/2020 -EndDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     09/30/2020
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with Configuration Logging details for the dates 09/01/2020 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 through}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 09/30/2020.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with Configuration Logging details for the dates 09/01/2020
+\par \hich\af2\dbch\af31505\loch\f2     through 09/30/2020.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ---------------------\hich\af2\dbch\af31505\loch\f2 ----- EXAMPLE 19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Logging -StartDate "09/01/2020 10:00:00" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 -EndDate "09/01/2020 14:00:00" -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSS\hich\af2\dbch\af31505\loch\f2 cript >.\\CVAD_Inventory_V3.ps1 -Logging -StartDate "09/01/2020 10:00:00"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     -EndDate "09/01/2020 14:00:00" -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with Configuration Logging details for the time range
-\par \hich\af2\dbch\af31505\loch\f2     09/01/2020 10:00:00AM through 09/01/2020 02:00:00PM.
+\par \hich\af2\dbch\af31505\loch\f2     09/01/2020 10:00:00AM through 09/01/2020 02:\hich\af2\dbch\af31505\loch\f2 00:00PM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all D\hich\af2\dbch\af31505\loch\f2 efault values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Sof\hich\af2\dbch\af31505\loch\f2 tware\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for \hich\af2\dbch\af31505\loch\f2 the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the\hich\af2\dbch\af31505\loch\f2  AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_In\hich\af2\dbch\af31505\loch\f2 ventory_V3.ps1 -Hosting
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Hosting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for Hosts, Host Connections, and Resources.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1366,7 +1368,7 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -StoreFront
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventor\hich\af2\dbch\af31505\loch\f2 y_V3.ps1 -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1374,13 +1376,14 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 22 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MachineCatalogs -DeliveryGroups }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 -Applications -Policies -Hosting -StoreFront
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.p\hich\af2\dbch\af31505\loch\f2 s1 -MachineCatalogs -DeliveryGroups}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     -Applications -Policies -Hosting -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all:
-\par \hich\af2\dbch\af31505\loch\f2         Ma\hich\af2\dbch\af31505\loch\f2 chines in all Machine Catalogs
+\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
@@ -1398,87 +1401,89 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
-\par \hich\af2\dbch\af31505\loch\f2         De\hich\af2\dbch\af31505\loch\f2 sktops in all Delivery Groups
-\par \hich\af2\dbch\af31505\loch\f2         Applications
+\par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Application\hich\af2\dbch\af31505\loch\f2 s
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_\hich\af2\dbch\af31505\loch\f2 CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running th\hich\af2\dbch\af31505\loch\f2 e script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 Consulting" -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserN\hich\af2\dbch\af31505\loch\f2 ame "Carl Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Nam\hich\af2\dbch\af31505\loch\f2 e.
-\par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 f\hich\af2\dbch\af31505\loch\f2 or the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\CVAD_Inventory_V3.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster" -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Creates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
-\par \hich\af2\dbch\af31505\loch\f2         The computer running the script fo\hich\af2\dbch\af31505\loch\f2 r the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2         The computer running the script\hich\af2\dbch\af31505\loch\f2  for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddr\hich\af2\dbch\af31505\loch\f2 ess "221B Baker
+\par \hich\af2\dbch\af31505\loch\f2     Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consu\hich\af2\dbch\af31505\loch\f2 lting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page form\hich\af2\dbch\af31505\loch\f2 at.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the C\hich\af2\dbch\af31505\loch\f2 ompany Phone.
-\par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminA\hich\af2\dbch\af31505\loch\f2 ddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 Consulting" -\hich\af2\dbch\af31505\loch\f2 CoverPage Facet -UserName "Dr. Watson" -CompanyEmail}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 \hich\af2\dbch\af31505\loch\f2  
-\par \hich\af2\dbch\af31505\loch\f2     S}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 uperSleuth@SherlockHolmes.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail
+\par \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
@@ -1487,10 +1492,10 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the \hich\af2\dbch\af31505\loch\f2 end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName_2020-06-01_1800.docx
@@ -1499,24 +1504,24 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------\hich\af2\dbch\af31505\loch\f2 ------------------- EXAMPLE 29 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -PDF -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript\hich\af2\dbch\af31505\loch\f2  >.\\CVAD_Inventory_V3.ps1 -PDF -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsof\hich\af2\dbch\af31505\loch\f2 t\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the e\hich\af2\dbch\af31505\loch\f2 nd of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2\hich\af2\dbch\af31505\loch\f2 020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName_2020-06-01_1800.pdf
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1525,7 +1530,7 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 30 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Ha\hich\af2\dbch\af31505\loch\f2 rdware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with hardware information for the Controllers.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1535,22 +1540,22 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps\hich\af2\dbch\af31505\loch\f2 1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The comp\hich\af2\dbch\af31505\loch\f2 uter running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ---\hich\af2\dbch\af31505\loch\f2 ----------------------- EXAMPLE 32 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report that contains only policy information.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
-\par \hich\af2\dbch\af31505\loch\f2     The c\hich\af2\dbch\af31505\loch\f2 omputer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Pro\hich\af2\dbch\af31505\loch\f2 cesses only the Policies section of the report.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1560,30 +1565,33 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Groups -DG
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups s\hich\af2\dbch\af31505\loch\f2 ection of the report with Delivery Group details.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with Delivery Group details.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 34 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------\hich\af2\dbch\af31505\loch\f2 ------------------- EXAMPLE 34 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -Section Groups
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Groups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with no Delivery Group details.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The compute\hich\af2\dbch\af31505\loch\f2 r running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXA\hich\af2\dbch\af31505\loch\f2 MPLE 35 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 35 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -BrokerRegistryKeys
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     *****Requires the script is run elevated*****
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds the information on over 300 Broker registry keys to the Controllers section.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for t\hich\af2\dbch\af31505\loch\f2 he AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1594,8 +1602,8 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     Adds the information on VDA registry keys to Appendix A.
-\par \hich\af2\dbch\af31505\loch\f2     Forces the\hich\af2\dbch\af31505\loch\f2  MachineCatalogs parameter to $True
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Forces the MachineCatalogs parameter to $True
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for th\hich\af2\dbch\af31505\loch\f2 e AdminAddress.
 \par 
 \par 
 \par 
@@ -1611,15 +1619,17 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Controllers         = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Hosting             = True
-\par \hich\af2\dbch\af31505\loch\f2         Logging             = True
+\par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
+\par \hich\af2\dbch\af31505\loch\f2         Log\hich\af2\dbch\af31505\loch\f2 ging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
 \par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
-\par \hich\af2\dbch\af31505\loch\f2         Section\hich\af2\dbch\af31505\loch\f2              = "All"
+\par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     *****Requires \hich\af2\dbch\af31505\loch\f2 the script is run elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1629,7 +1639,7 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 38 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V\hich\af2\dbch\af31505\loch\f2 3.ps1 -MaxDetails -HTML -MSWord -PDF -Text
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MaxDetails -HTML -\hich\af2\dbch\af31505\loch\f2 MSWord -PDF -Text
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
 \par 
@@ -1639,7 +1649,7 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1647,18 +1657,20 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
-\par \hich\af2\dbch\af31505\loch\f2         Controllers         = True
+\par \hich\af2\dbch\af31505\loch\f2         Controllers         = \hich\af2\dbch\af31505\loch\f2 True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Hosting             = True
+\par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
-\par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   VDARegistryKeys     = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
 \par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     *****Requires the script is run elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1667,15 +1679,15 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 39 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Dev -S\hich\af2\dbch\af31505\loch\f2 criptInfo -Log
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Dev -ScriptInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file name\hich\af2\dbch\af31505\loch\f2 d CVADInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptInfo_yyyy-MM-dd_H\hich\af2\dbch\af31505\loch\f2 Hmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic infor\hich\af2\dbch\af31505\loch\f2 mation.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
 \par \hich\af2\dbch\af31505\loch\f2     CVADDocScriptTranscript_yyyy-MM-dd_HHmm.txt.
@@ -1687,30 +1699,31 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -CSV
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Defa\hich\af2\dbch\af31505\loch\f2 ult values.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendix.
 \par \hich\af2\dbch\af31505\loch\f2     For example:
-\par \hich\af2\dbch\af31505\loch\f2         CVAD\hich\af2\dbch\af31505\loch\f2 SiteName_Documentation_AppendixA_VDARegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixD_CitrixI\hich\af2\dbch\af31505\loch\f2 nstalledComponents.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentat\hich\af2\dbch\af31505\loch\f2 ion_AppendixE_WindowsInstalledComponents.csv
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 41 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MaxDetails -HTML -MSWord -PDF -Text -D\hich\af2\dbch\af31505\loch\f2 ev }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 -ScriptInfo -Log -CSV
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MaxDetails -HTML -MSWord -PDF -Text -Dev}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo -Log -CSV
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
+\par \hich\af2\dbch\af31505\loch\f2     Creates four report\hich\af2\dbch\af31505\loch\f2 s: HTML, Microsoft Word, PDF, and plain text.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Create\hich\af2\dbch\af31505\loch\f2 s a text file named CVADInventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptInfo_yyyy-MM-dd\hich\af2\dbch\af31505\loch\f2 _HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
@@ -1720,26 +1733,26 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2     For example:
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.csv
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixC_MicrosoftHotf\hich\af2\dbch\af31505\loch\f2 ixesandUpdates.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     For Microsoft Word and PDF, wil\hich\af2\dbch\af31505\loch\f2 l use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     For Microsoft Word and PDF, will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\So\hich\af2\dbch\af31505\loch\f2 ftware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl W\hich\af2\dbch\af31505\loch\f2 ebster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the \hich\af2\dbch\af31505\loch\f2 Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Controllers         = True
-\par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
+\par \hich\af2\dbch\af31505\loch\f2         Controllers         = True
+\par \hich\af2\dbch\af31505\loch\f2         DeliveryGro\hich\af2\dbch\af31505\loch\f2 ups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
@@ -1752,23 +1765,26 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
 \par 
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     *****Requires the script is run elevated*****
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 42 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 42 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 CVADAdmin@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 CVADAdmin@domain.tld,sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     CVADAdmin@domain.tld -To ITGroup@domain.tld
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld\hich\af2\dbch\af31505\loch\f2 , sending from
+\par \hich\af2\dbch\af31505\loch\f2     CVADAdmin@domain.tld, sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid\hich\af2\dbch\af31505\loch\f2  credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1778,33 +1794,33 @@ yKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 43 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 Anonymou\hich\af2\dbch\af31505\loch\f2 s@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     an\hich\af2\dbch\af31505\loch\f2 onymous@domain.tld, sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an e\hich\af2\dbch\af31505\loch\f2 mail relay server requires the From email account
+\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
 \par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid4462158 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     **\hich\af2\dbch\af31505\loch\f2 *GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 
+"https://support.google.com/a/answer/2956491?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000f}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16154053\charrsid4462158 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid4462158 {\*\datafield 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300c3000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16154053\charrsid4462158 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure\hich\af2\dbch\af31505\loch\f2  app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on \hich\af2\dbch\af31505\loch\f2 your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
@@ -1818,30 +1834,29 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 44 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 labaddomain-com.mail.protection.outlook.com -UseSSL -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer
+\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     S\hich\af2\dbch\af31505\loch\f2 omeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-\hich\af2\dbch\af31505\loch\f2 3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-{\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-o\hich\af2\dbch\af31505\loch\f2 ffice-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid15405088 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000042f400}}}{\fldrslt {
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16154053\charrsid4462158 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us\hich\af2\dbch\af31505\loch\f2 
-/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15405088\charrsid15405088 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
+}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15405088\charrsid15405088 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
+\par \hich\af2\dbch\af31505\loch\f2     This u\hich\af2\dbch\af31505\loch\f2 ses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail\hich\af2\dbch\af31505\loch\f2 .protection.outlook.com,
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
 \par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 will use the default SMTP port 25 and will use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1851,25 +1866,24 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 45 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 -UseSSL -From Webster@CarlWebs\hich\af2\dbch\af31505\loch\f2 ter.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     The script will use t\hich\af2\dbch\af31505\loch\f2 he email server smtp.office365.com on port 587 using SSL,
 \par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to se\hich\af2\dbch\af31505\loch\f2 nd email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credent\hich\af2\dbch\af31505\loch\f2 ials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 46 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_\hich\af2\dbch\af31505\loch\f2 Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4462158 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16154053\charrsid16154053 \hich\af2\dbch\af31505\loch\f2 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
@@ -1884,7 +1898,6 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
@@ -2006,10 +2019,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000102b
-b003ac87d60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000102bb003ac87d601
-102bb003ac87d60100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000102bb003ac87
-d601102bb003ac87d6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000c070
+ea67e997d60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000c070ea67e997d601
+c070ea67e997d60100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000c070ea67e997
+d601c070ea67e997d6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/CVAD_V3_Script_ChangeLog.txt
+++ b/CVAD_V3_Script_ChangeLog.txt
@@ -6,6 +6,23 @@
 
 # This script is based on the 2.36 script
 
+#Version 3.10 1-Oct-2020
+#	Add Hosting Connection type Remote PC Wake on LAN
+#	Add version 7.27 for CVAD 2009 to version table
+#	Added the following new Administrator Role permissions:
+#		App-V
+#			Add App-V applications
+#			Remove App-V applications
+#	Added three new User policy settings
+#		ICA\FIDO2 Redirection
+#		ICA\Limit clipboard client to session transfer size
+#		ICA\Limit clipboard session to client transfer size
+#	Changed testing for existing PSDrives from Get-PSDrive to Test-Path
+#	Fix three uninitialized variables
+#	If BrokerRegistryKeys is True, test for elevation
+#		Update help text to show elevation is required when using BrokerRegistryKeys
+#	When getting the Master VM for an MCS based machine catalog, also check for images ending in .template for Nutanix
+
 #Version 3.01 11-Sep-2020
 #	Add a switch statement for the machine/desktop/server Power State
 #	Change all Write-Verbose $(Get-Date) to add -Format G to put the dates in the user's locale


### PR DESCRIPTION
#Version 3.10 1-Oct-2020
#	Add Hosting Connection type Remote PC Wake on LAN
#	Add version 7.27 for CVAD 2009 to version table
#	Added the following new Administrator Role permissions:
#		App-V
#			Add App-V applications
#			Remove App-V applications
#	Added three new User policy settings
#		ICA\FIDO2 Redirection
#		ICA\Limit clipboard client to session transfer size
#		ICA\Limit clipboard session to client transfer size
#	Changed testing for existing PSDrives from Get-PSDrive to Test-Path
#	Fix three uninitialized variables
#	If BrokerRegistryKeys is True, test for elevation
#		Update help text to show elevation is required when using BrokerRegistryKeys
#	When getting the Master VM for an MCS based machine catalog, also check for images ending in .template for Nutanix