### PR TITLE
Final update for 3.23

### DIFF
--- a/CVAD_Inventory_V3_ReadMe.rtf
+++ b/CVAD_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -84,22 +84,23 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \rsid2653562\rsid2902416\rsid2978753\rsid3097678\rsid3151791\rsid3300860\rsid3430394\rsid3505396\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4138244\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4462158\rsid4522193\rsid4740061\rsid4745200
 \rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5207971\rsid5209339\rsid5267713\rsid5339870\rsid5703879\rsid5728664\rsid5847035\rsid6053627\rsid6054960\rsid6058160\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6635878\rsid6637724\rsid6947370
 \rsid6966385\rsid7432229\rsid7560681\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828\rsid8662784\rsid8790405\rsid8876191\rsid9047498\rsid9112866\rsid9338186\rsid9376723\rsid9503154\rsid9520485\rsid9532820
-\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10578344\rsid10580546\rsid10900280\rsid10963467\rsid10967884\rsid11041950\rsid11227030\rsid11345509\rsid11488686\rsid11605034\rsid11823514\rsid11884716
-\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13270439\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13853169\rsid13966007\rsid13976227
-\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14362273\rsid14577313\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid15405088\rsid15428007\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid15739384
-\rsid15802422\rsid15873118\rsid15948729\rsid16017241\rsid16017738\rsid16085929\rsid16154053\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420\rsid16597410\rsid16669189\rsid16671705
-\rsid16713983}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo1\dy25\hr7\min35}{\version111}
-{\edmins11928}{\nofpages30}{\nofwords8815}{\nofchars50252}{\nofcharsws58950}{\vern15}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10303296\rsid10315109\rsid10488541\rsid10578344\rsid10580546\rsid10900280\rsid10963467\rsid10967884\rsid11041950\rsid11227030\rsid11345509\rsid11488686\rsid11605034\rsid11823514
+\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13270439\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13853169\rsid13966007
+\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14362273\rsid14577313\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid14964124\rsid15346731\rsid15405088\rsid15428007\rsid15613047\rsid15623927
+\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16017241\rsid16017738\rsid16085929\rsid16154053\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420
+\rsid16597410\rsid16669189\rsid16671705\rsid16713983}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
+{\revtim\yr2021\mo1\dy30\hr10\min44}{\version113}{\edmins11930}{\nofpages30}{\nofwords8815}{\nofchars50249}{\nofcharsws58947}{\vern15}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBUZmtQDNX6KxLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16085929 \chftnsep 
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBUbmtQCMbrmoLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15346731 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16085929 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15346731 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16085929 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15346731 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16085929 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15346731 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid16203271 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 
@@ -210,7 +211,7 @@ Citrix Desktop Delivery Controller\\XDPoshSnapin_x??
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d000000009f009133000002000000000000450036410a0000004100}}}{\fldrslt {
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d000000009f009133000002000000000000450036410a00000041005e}}}{\fldrslt {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
@@ -288,7 +289,7 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16154053 \hich\af37\dbch\af31505\loch\f37 CVAD_Inventory_V3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
 \par 
-\par \hich\af37\dbch\af31505\loch\f37 The help text expla\hich\af37\dbch\af31505\loch\f37 ins all the parameters the script accepts.
+\par \hich\af37\dbch\af31505\loch\f37 The help text explains all th\hich\af37\dbch\af31505\loch\f37 e parameters the script accepts.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11345509 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8394203 \page \hich\af43\dbch\af31505\loch\f43 Help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
 \par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
@@ -304,66 +305,64 @@ CVAD_Inventory_V3.ps1
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \\\hich\af2\dbch\af31505\loch\f2 
 CVAD_Inventory_V3.ps1 [-AdminAddress <String>] [-HTML] [-Text] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-Applications] [-BrokerRegistryKeys] [-Controllers] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-Applications] [-BrokerRegistryKeys] [-Controllers] [-Hardwa\hich\af2\dbch\af31505\loch\f2 
+re] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5728664 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 [-D\hich\af2\dbch\af31505\loch\f2 eliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate 
-}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-NoADPolicies] [-NoPolicies]}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2     [-NoSessions] [-Policies] [-StoreFront] [-VDARegistryKeys] [-MaxDetails] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5728664 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 <String>\hich\af2\dbch\af31505\loch\f2 ] [-AddDateTime] [-CSV] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2     [-NoSessions] [-Policies] [-StoreFront] [-VDARegistryKeys] [-MaxDetails] \hich\af2\dbch\af31505\loch\f2 [-Section }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5728664 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 <String>] [-AddDateTime] [-CSV] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 [-MSWord] [-PDF] [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 [-UserName <String\hich\af2\dbch\af31505\loch\f2 >] [-SmtpServer <String>] [-SmtpPort <Int32>] [-UseSSL] [-From 
-}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 [-UserName <String>] [-SmtpServer <String>] [-SmtpPort <Int32>] [-UseSSL] [-From }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 <String>] [-To <String>] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix Virtual Apps and Desktops (CVAD) 2006 or later Site
-\par \hich\af2\dbch\af31505\loch\f2     using Microsoft PowerShell, Word, plain \hich\af2\dbch\af31505\loch\f2 text, or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory\hich\af2\dbch\af31505\loch\f2  of a Citrix Virtual Apps and Desktops (CVAD) 2006 or later Site
+\par \hich\af2\dbch\af31505\loch\f2     using Microsoft PowerShell, Word, plain text, or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This script requires at least PowerShell version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Default output is now HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and run
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on\hich\af2\dbch\af31505\loch\f2  a Controller. This script was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You can run this script remot\hich\af2\dbch\af31505\loch\f2 ely using the \hich\f2 \endash \loch\f2 AdminAddress (AA) parameter.
+\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the \hich\f2 \endash \loch\f2 AdminAddress (AA) parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This script supports versions of CVAD starting with 2006.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If you are running XA/XD 7.0 through 7.7, please use:\hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  
-\hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     If you are running XA/XD 7.0 throug\hich\af2\dbch\af31505\loch\f2 h 7.7, please use:    }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
 }{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If you are running XA/XD 7.8 through CVAD 2006, please use:
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/xe\hich\af2\dbch\af31505\loch\f2 
+nappxendesktop-7-8/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If you are runnin\hich\af2\dbch\af31505\loch\f2 g Citrix Cloud, please use:\hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
-\hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     If you are runni\hich\af2\dbch\af31505\loch\f2 ng Citrix Cloud, please use:    }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be6000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
 64002d0069006e0066006f002f006300690074007200690078002d0063006c006f00750064002d006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d0073006500720076006900630065002f000000795881
-f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+f43b1d7f48af2c825dc485276300000000a5ab000370}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
 https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have at least Read access to the SQL
-\par \hich\af2\dbch\af31505\loch\f2     Server(s) that hold(s) the C\hich\af2\dbch\af31505\loch\f2 itrix Site, Monitoring, and Logging databases.
+\par \hich\af2\dbch\af31505\loch\f2     Server(s) that hold(s) the Citrix Site, Monitoring, and Logging databases.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
@@ -375,7 +374,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
-\par \hich\af2\dbch\af31505\loch\f2         Policies
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Policies
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2         Zones
 \par 
@@ -386,24 +385,24 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Controllers
-\par \hich\af2\dbch\af31505\loch\f2         Administrators
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
-\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an e\hich\af2\dbch\af31505\loch\f2 xtremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
-\par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     take an extremely \hich\af2\dbch\af31505\loch\f2 long time to complete and generate an exceptionally long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using BrokerRegistryKeys requires the script runs elevated.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the CVAD Site.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page\hich\af2\dbch\af31505\loch\f2 , Table of Contents and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and\hich\af2\dbch\af31505\loch\f2  Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
@@ -415,7 +414,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
-\par \hich\af2\dbch\af31505\loch\f2         Spanish
+\par \hich\af2\dbch\af31505\loch\f2         Spa\hich\af2\dbch\af31505\loch\f2 nish
 \par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
 \par 
@@ -423,62 +422,62 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a CVAD controller the PowerShell snapins will connect
 \par \hich\af2\dbch\af31505\loch\f2         to.
-\par \hich\af2\dbch\af31505\loch\f2         This can be provided as a hostname or an\hich\af2\dbch\af31505\loch\f2  IP address.
+\par \hich\af2\dbch\af31505\loch\f2         This can be provided as a hostname or an IP address.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to Localhost.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Localhost
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipel\hich\af2\dbch\af31505\loch\f2 ine input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an.html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?              \hich\af2\dbch\af31505\loch\f2       false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a.txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a.txt exten\hich\af2\dbch\af31505\loch\f2 sion.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipe\hich\af2\dbch\af31505\loch\f2 line input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Administrator Scopes and Roles.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an a\hich\af2\dbch\af31505\loch\f2 lias of Admins.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Admins.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Applications [<Swi\hich\af2\dbch\af31505\loch\f2 tchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         G\hich\af2\dbch\af31505\loch\f2 ives detailed information for all applications.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value        \hich\af2\dbch\af31505\loch\f2         False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registr\hich\af2\dbch\af31505\loch\f2 y keys to the Controller section.
+\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller section.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         *****Requires the script runs elevated*****
+\par \hich\af2\dbch\af31505\loch\f2         *****Requires the script runs\hich\af2\dbch\af31505\loch\f2  elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
 \par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controller, to the report.
@@ -487,23 +486,23 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    name\hich\af2\dbch\af31505\loch\f2 d
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?     \hich\af2\dbch\af31505\loch\f2   false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Controllers [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Lists the following information to the Controllers section:
-\par \hich\af2\dbch\af31505\loch\f2                 List of installed Microsoft Hotfixes and Updates
-\par \hich\af2\dbch\af31505\loch\f2                 List of Citrix ins\hich\af2\dbch\af31505\loch\f2 talled components
+\par \hich\af2\dbch\af31505\loch\f2                 Lis\hich\af2\dbch\af31505\loch\f2 t of installed Microsoft Hotfixes and Updates
+\par \hich\af2\dbch\af31505\loch\f2                 List of Citrix installed components
 \par \hich\af2\dbch\af31505\loch\f2                 List of Windows installed Roles and Features
 \par \hich\af2\dbch\af31505\loch\f2                 Appendix C List of installed Microsoft Hotfixes and Updates for all
-\par \hich\af2\dbch\af31505\loch\f2                 Controllers
+\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Appendix D List of Citrix installed components for all Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Appendix E List of Windows installed Roles and Features for all Controllers
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an ali\hich\af2\dbch\af31505\loch\f2 as of DDC.
+\par \hich\af2\dbch\af31505\loch\f2         This param\hich\af2\dbch\af31505\loch\f2 eter has an alias of DDC.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -511,60 +510,60 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParame\hich\af2\dbch\af31505\loch\f2 ter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permissio\hich\af2\dbch\af31505\loch\f2 n to retrieve hardware information (i.e. Domain Admin
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run fro\hich\af2\dbch\af31505\loch\f2 m an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
 \par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
-\par \hich\af2\dbch\af31505\loch\f2         size of the report.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   size of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter has an alias of HW.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accep\hich\af2\dbch\af31505\loch\f2 t pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information on all desktops in all Desktop (Delivery) Groups.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter \hich\af2\dbch\af31505\loch\f2 can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the\hich\af2\dbch\af31505\loch\f2  report to take a very long
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and g\hich\af2\dbch\af31505\loch\f2 enerate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
 \par \hich\af2\dbch\af31505\loch\f2         long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value           \hich\af2\dbch\af31505\loch\f2      False
+\par \hich\af2\dbch\af31505\loch\f2         Posi\hich\af2\dbch\af31505\loch\f2 tion?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
-\par \hich\af2\dbch\af31505\loch\f2         depending on the info\hich\af2\dbch\af31505\loch\f2 rmation in the database.
+\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery grou\hich\af2\dbch\af31505\loch\f2 p utilization for the last 7 days
+\par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
 \par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be locally installed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGro\hich\af2\dbch\af31505\loch\f2 upsUtilization parameter causes the report to take a longer
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required? \hich\af2\dbch\af31505\loch\f2                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -585,13 +584,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous
 \par \hich\af2\dbch\af31505\loch\f2         seven days.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         The start date for the Configuration Logging report.
@@ -599,58 +598,58 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         The format for date only is MM/DD/YYYY.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
-\par \hich\af2\dbch\af31505\loch\f2         The double \hich\af2\dbch\af31505\loch\f2 quotes are needed.
+\par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date minus seven days.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SD.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?          \hich\af2\dbch\af31505\loch\f2           false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -dis\hich\af2\dbch\af31505\loch\f2 playhint date).AddDays(-7))
+\par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2         The end date for the Configuration Logging report.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   The end date for the Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The format for date only is MM/DD/YYYY.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default is today's date.
+\par \hich\af2\dbch\af31505\loch\f2         The default is\hich\af2\dbch\af31505\loch\f2  today's date.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ED.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detail\hich\af2\dbch\af31505\loch\f2 ed information for all machines in all Machine Catalogs.
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 time to complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and D\hich\af2\dbch\af31505\loch\f2 eliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
 \par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
 \par \hich\af2\dbch\af31505\loch\f2         long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required\hich\af2\dbch\af31505\loch\f2 ?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information from the output document.
 \par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This Switch is useful in large AD environments, where there may be thous\hich\af2\dbch\af31505\loch\f2 ands
+\par \hich\af2\dbch\af31505\loch\f2         This Switch is useful i\hich\af2\dbch\af31505\loch\f2 n large AD environments, where there may be thousands
 \par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -658,56 +657,56 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defaul\hich\af2\dbch\af31505\loch\f2 t value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD-based policy information from the output document.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Usin\hich\af2\dbch\af31505\loch\f2 g the NoPolicies parameter will cause the Policies parameter to be set to False.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    nam\hich\af2\dbch\af31505\loch\f2 ed
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoSessions [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Excludes all Site and Citrix AD-based policy information from the output document.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has \hich\af2\dbch\af31505\loch\f2 an alias of NP.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoSessions [<Switc\hich\af2\dbch\af31505\loch\f2 hParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes Machine Catalog, Application and Hosting session data from the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the MaxDetails parameter does not change this setting.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NS.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias o\hich\af2\dbch\af31505\loch\f2 f NS.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give\hich\af2\dbch\af31505\loch\f2  detailed information for both Site and Citrix AD-based Policies.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD-based Policies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
-\par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2         to compl\hich\af2\dbch\af31505\loch\f2 ete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters\hich\af2\dbch\af31505\loch\f2 : Policies, NoPolicies, and NoADPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies, and NoADPolicies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disa\hich\af2\dbch\af31505\loch\f2 bled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcar\hich\af2\dbch\af31505\loch\f2 d characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StoreFront [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for StoreFront.
@@ -715,7 +714,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?              \hich\af2\dbch\af31505\loch\f2       named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -728,16 +727,16 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of VRK.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?   \hich\af2\dbch\af31505\loch\f2                  false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
+\par \hich\af2\dbch\af31505\loch\f2         Adds maximum det\hich\af2\dbch\af31505\loch\f2 ail to the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is the same as using the followin\hich\af2\dbch\af31505\loch\f2 g parameters:
+\par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
 \par \hich\af2\dbch\af31505\loch\f2                 Administrators
 \par \hich\af2\dbch\af31505\loch\f2                 Applications
 \par \hich\af2\dbch\af31505\loch\f2                 BrokerRegistryKeys
@@ -746,12 +745,12 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2                 HardWare
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2                 MachineCatalogs
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
 \par \hich\af2\dbch\af31505\loch\f2                 StoreFront
 \par \hich\af2\dbch\af31505\loch\f2                 VDARegistryKeys
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         *****Requires the script runs elevated*****
+\par \hich\af2\dbch\af31505\loch\f2         *****Requires the script ru\hich\af2\dbch\af31505\loch\f2 ns elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoADPolicies.
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoSessions.
@@ -759,7 +758,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
+\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter has an alias of MAX.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -767,9 +766,9 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Section <String>
+\par \hich\af2\dbch\af31505\loch\f2     -Secti\hich\af2\dbch\af31505\loch\f2 on <String>
 \par \hich\af2\dbch\af31505\loch\f2         Processes a specific section of the report.
-\par \hich\af2\dbch\af31505\loch\f2         V\hich\af2\dbch\af31505\loch\f2 alid options are:
+\par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
 \par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications and Application Group Details)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
@@ -777,7 +776,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Groups (Delivery Groups)
-\par \hich\af2\dbch\af31505\loch\f2                 Hosting
+\par \hich\af2\dbch\af31505\loch\f2                 H\hich\af2\dbch\af31505\loch\f2 osting
 \par \hich\af2\dbch\af31505\loch\f2                 Licensing
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
@@ -787,14 +786,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Notes:
-\par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Logging Switch to True.
+\par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Log\hich\af2\dbch\af31505\loch\f2 ging Switch to True.
 \par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies Switch to True.
 \par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies Switch is used, the script will terminate.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                 \hich\af2\dbch\af31505\loch\f2    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
@@ -803,27 +802,27 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.docx (or.pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has a\hich\af2\dbch\af31505\loch\f2 n alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CSV [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -CSV [<SwitchParame\hich\af2\dbch\af31505\loch\f2 ter>]
 \par \hich\af2\dbch\af31505\loch\f2         Will create a CSV file for each Appendix.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Output\hich\af2\dbch\af31505\loch\f2  CSV filename is in the format:
+\par \hich\af2\dbch\af31505\loch\f2         Output CSV filename is in the format:
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_Appendix#_NameOfAppendix.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For example:
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_D\hich\af2\dbch\af31505\loch\f2 ocumentation_AppendixA_VDARegistryItems.csv
 \par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.csv
 \par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_App\hich\af2\dbch\af31505\loch\f2 endixD_CitrixInstalledComponents.csv
 \par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -848,13 +847,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the\hich\af2\dbch\af31505\loch\f2  output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characte\hich\af2\dbch\af31505\loch\f2 rs?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
@@ -862,15 +861,15 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?     \hich\af2\dbch\af31505\loch\f2   false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script runs.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is d\hich\af2\dbch\af31505\loch\f2 isabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -878,38 +877,38 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<Swi\hich\af2\dbch\af31505\loch\f2 tchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?    \hich\af2\dbch\af31505\loch\f2                 named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is dis\hich\af2\dbch\af31505\loch\f2 abled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if t\hich\af2\dbch\af31505\loch\f2 he Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has \hich\af2\dbch\af31505\loch\f2 the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Da\hich\af2\dbch\af31505\loch\f2 rk) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
@@ -936,14 +935,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Ac\hich\af2\dbch\af31505\loch\f2 cept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax fi\hich\af2\dbch\af31505\loch\f2 eld.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 C\hich\af2\dbch\af31505\loch\f2 ontrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
@@ -956,11 +955,11 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for th\hich\af2\dbch\af31505\loch\f2 e Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the\hich\af2\dbch\af31505\loch\f2  Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer running the scrip\hich\af2\dbch\af31505\loch\f2 t.
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
@@ -968,38 +967,38 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeli\hich\af2\dbch\af31505\loch\f2 ne input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Pho\hich\af2\dbch\af31505\loch\f2 ne field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias \hich\af2\dbch\af31505\loch\f2 of CPh.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
-\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word \hich\af2\dbch\af31505\loch\f2 Cover Page to use.
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page \hich\af2\dbch\af31505\loch\f2 to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 works in 2010, but Subtitle/Subject & Author \hich\af2\dbch\af31505\loch\f2 fields need moving
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010, but Subtitle/Subject & Author fields need moving
 \par \hich\af2\dbch\af31505\loch\f2                 after the title box is moved up)
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2               \hich\af2\dbch\af31505\loch\f2   Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
@@ -1020,42 +1019,42 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 R\hich\af2\dbch\af31505\loch\f2 etrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. D\hich\af2\dbch\af31505\loch\f2 oesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word \hich\af2\dbch\af31505\loch\f2 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MS\hich\af2\dbch\af31505\loch\f2 WORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Req\hich\af2\dbch\af31505\loch\f2 uired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Username to use f\hich\af2\dbch\af31505\loch\f2 or the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to sen\hich\af2\dbch\af31505\loch\f2 d the output report.
+\par \hich\af2\dbch\af31505\loch\f2         S\hich\af2\dbch\af31505\loch\f2 pecifies the optional email server to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1064,13 +1063,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies\hich\af2\dbch\af31505\loch\f2  the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
@@ -1078,14 +1077,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 osition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a require\hich\af2\dbch\af31505\loch\f2 d parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If Smt\hich\af2\dbch\af31505\loch\f2 pServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1094,23 +1093,23 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username\hich\af2\dbch\af31505\loch\f2  for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                \hich\af2\dbch\af31505\loch\f2     named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept w\hich\af2\dbch\af31505\loch\f2 ildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more inform\hich\af2\dbch\af31505\loch\f2 ation, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAct\hich\af2\dbch\af31505\loch\f2 ion, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
@@ -1119,16 +1118,17 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
-\par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, plain text, or HTML document.
+\par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, p\hich\af2\dbch\af31505\loch\f2 lain text, or HTML document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: CVAD_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.22
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14964124 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: January 25, 2021
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: January }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14964124 \hich\af2\dbch\af31505\loch\f2 30}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
+\hich\af2\dbch\af31505\loch\f2 , 2021
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1147,13 +1147,13 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKE\hich\af2\dbch\af31505\loch\f2 Y_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft W\hich\af2\dbch\af31505\loch\f2 ord report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1164,7 +1164,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
-\par \hich\af2\dbch\af31505\loch\f2     DDC01\hich\af2\dbch\af31505\loch\f2  for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     DDC01 for the Adm\hich\af2\dbch\af31505\loch\f2 inAddress.
 \par 
 \par 
 \par 
@@ -1175,10 +1175,10 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1190,7 +1190,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Text
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Tex\hich\af2\dbch\af31505\loch\f2 t
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Saves the document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1202,13 +1202,13 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -HTML
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Saves the document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     Saves the document\hich\af2\dbch\af31505\loch\f2  as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXA\hich\af2\dbch\af31505\loch\f2 MPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MachineCatalogs
 \par 
@@ -1218,20 +1218,20 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 8 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V\hich\af2\dbch\af31505\loch\f2 3.ps1 -DeliveryGroups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all desktops in all Desktop (Delivery)
 \par \hich\af2\dbch\af31505\loch\f2     Groups.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script \hich\af2\dbch\af31505\loch\f2 for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroupsUtilization -MSWord
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroupsUtilization -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requires the use of MSWord or PDF.
 \par 
@@ -1239,14 +1239,14 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     Groups.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     A\hich\af2\dbch\af31505\loch\f2 dministrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1258,17 +1258,17 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requires the use of MSWord or PDF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with utilization details for all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with utilization details for all Desktop (Deliver\hich\af2\dbch\af31505\loch\f2 y) Groups.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administra\hich\af2\dbch\af31505\loch\f2 tor
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator fo\hich\af2\dbch\af31505\loch\f2 r the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1278,8 +1278,8 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups -MachineCatalogs
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report wi\hich\af2\dbch\af31505\loch\f2 th full details for all machines in all Machine Catalogs and
-\par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all machines in all Machine Catalogs and
+\par \hich\af2\dbch\af31505\loch\f2     all desktops i\hich\af2\dbch\af31505\loch\f2 n all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1289,7 +1289,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full detai\hich\af2\dbch\af31505\loch\f2 ls for all applications.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1305,11 +1305,11 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----\hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -NoPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with no Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Crea\hich\af2\dbch\af31505\loch\f2 tes an HTML report with no Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1319,7 +1319,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with no Citrix AD-based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTM\hich\af2\dbch\af31505\loch\f2 L report with no Citrix AD-based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1327,35 +1327,34 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Policies -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -Policies -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on Site policies created in Studio but
-\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD-based Poli\hich\af2\dbch\af31505\loch\f2 cy information.
+\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD-based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 17 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Administrators
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details o\hich\af2\dbch\af31505\loch\f2 n Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on Administrator Scopes and Roles.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -------------------------- EXAMPLE 18 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Logging -StartDate 09/01/2021 -EndDate
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     09/30/2021
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with Configuration Logging details for the dates 09/01/2021
 \par \hich\af2\dbch\af31505\loch\f2     through 09/30/2021.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the \hich\af2\dbch\af31505\loch\f2 AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1363,20 +1362,20 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Logging -StartDate "09/01/2021 10:00:00"
-\par \hich\af2\dbch\af31505\loch\f2     -EndDate "09/01/2021 14:00:00" -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     -EndDate "\hich\af2\dbch\af31505\loch\f2 09/01/2021 14:00:00" -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report w\hich\af2\dbch\af31505\loch\f2 ith Configuration Logging details for the time range
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with Configuration Logging details for the time range
 \par \hich\af2\dbch\af31505\loch\f2     09/01/2021 10:00:00AM through 09/01/2021 02:00:00PM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
+\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either\hich\af2\dbch\af31505\loch\f2  00 or 59.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administra\hich\af2\dbch\af31505\loch\f2 tor
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1386,20 +1385,20 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 \hich\af2\dbch\af31505\loch\f2 -Hosting
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Hosting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for Hosts, Host Connections, and Resources.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the\hich\af2\dbch\af31505\loch\f2  AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVA\hich\af2\dbch\af31505\loch\f2 D_Inventory_V3.ps1 -StoreFront
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for StoreFront.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the Admin\hich\af2\dbch\af31505\loch\f2 Address.
 \par 
 \par 
 \par 
@@ -1410,8 +1409,8 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications -Policies -Hosting -StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all:
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Machines in all Machine Catalogs
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details \hich\af2\dbch\af31505\loch\f2 for all:
+\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
@@ -1423,11 +1422,11 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 23 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MC -DG -Apps -Policies -Hosting -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with full details for all:
+\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with full detail\hich\af2\dbch\af31505\loch\f2 s for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
@@ -1435,23 +1434,23 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\C\hich\af2\dbch\af31505\loch\f2 ommon\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer runn\hich\af2\dbch\af31505\loch\f2 ing the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -A\hich\af2\dbch\af31505\loch\f2 dminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps\hich\af2\dbch\af31505\loch\f2 1 -MSWord -CompanyName "Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
@@ -1468,30 +1467,30 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -CN "Carl Webster Consulting" -CP "Mod"
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Cre\hich\af2\dbch\af31505\loch\f2 ates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
-\par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the Ad\hich\af2\dbch\af31505\loch\f2 minAddress.
+\par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B B\hich\af2\dbch\af31505\loch\f2 aker
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName\hich\af2\dbch\af31505\loch\f2  "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker
 \par \hich\af2\dbch\af31505\loch\f2     Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sher\hich\af2\dbch\af31505\loch\f2 lock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     +44 1753 276200 for the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753\hich\af2\dbch\af31505\loch\f2  276200 for the Company Phone.
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1499,14 +1498,14 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlo\hich\af2\dbch\af31505\loch\f2 ck Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail
 \par \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page fo\hich\af2\dbch\af31505\loch\f2 rmat.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the \hich\af2\dbch\af31505\loch\f2 Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
@@ -1514,14 +1513,14 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAM\hich\af2\dbch\af31505\loch\f2 PLE 28 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-M\hich\af2\dbch\af31505\loch\f2 M-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM \hich\af2\dbch\af31505\loch\f2 is 2021-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName_2021-06-01_1800.docx
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1530,24 +1529,24 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS \hich\af2\dbch\af31505\loch\f2 C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -PDF -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -PDF -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values and saves the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover P\hich\af2\dbch\af31505\loch\f2 age format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName_2021-06-01_1800.pdf
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName_2021-06-01\hich\af2\dbch\af31505\loch\f2 _1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1556,7 +1555,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Hardware
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with hardware information for the Controller\hich\af2\dbch\af31505\loch\f2 s.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with hardware information for th\hich\af2\dbch\af31505\loch\f2 e Controllers.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1567,7 +1566,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Output file i\hich\af2\dbch\af31505\loch\f2 s saved in the path \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     Output file is saved in the path \\\\FileServer\\ShareName
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1575,7 +1574,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Policies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory\hich\af2\dbch\af31505\loch\f2 _V3.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report that contains only policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
@@ -1584,7 +1583,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 33 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 33 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Groups -DG
 \par 
@@ -1600,7 +1599,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Groups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with no Delivery Group details.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section o\hich\af2\dbch\af31505\loch\f2 f the report with no Delivery Group details.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1608,9 +1607,9 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 35 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inve\hich\af2\dbch\af31505\loch\f2 ntory_V3.ps1 -BrokerRegistryKeys
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -BrokerRegistryKeys
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an\hich\af2\dbch\af31505\loch\f2  HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *****Requires the script runs elevated*****
 \par 
@@ -1625,8 +1624,8 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -VDARegistryKeys
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Adds the information on VDA registry keys to Appendix A.
-\par \hich\af2\dbch\af31505\loch\f2     Forces the MachineCatalogs \hich\af2\dbch\af31505\loch\f2 parameter to $True
+\par \hich\af2\dbch\af31505\loch\f2     Adds the information on VDA re\hich\af2\dbch\af31505\loch\f2 gistry keys to Appendix A.
+\par \hich\af2\dbch\af31505\loch\f2     Forces the MachineCatalogs parameter to $True
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1634,21 +1633,21 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 37 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MaxDetails
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Ma\hich\af2\dbch\af31505\loch\f2 xDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
 \par \hich\af2\dbch\af31505\loch\f2         Controllers         = True
-\par \hich\af2\dbch\af31505\loch\f2         DeliveryGro\hich\af2\dbch\af31505\loch\f2 ups      = True
-\par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
+\par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
+\par \hich\af2\dbch\af31505\loch\f2         HardWare            = T\hich\af2\dbch\af31505\loch\f2 rue
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
-\par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = \hich\af2\dbch\af31505\loch\f2 True
+\par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
 \par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
@@ -1668,8 +1667,8 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Microsoft Word and PDF, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
-\hich\af2\dbch\af31505\loch\f2 s\hich\af2\dbch\af31505\loch\f2 es all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\hich\af2\dbch\af31505\loch\f2 ses all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1689,7 +1688,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
-\par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
+\par \hich\af2\dbch\af31505\loch\f2         StoreFront\hich\af2\dbch\af31505\loch\f2           = True
 \par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
@@ -1697,52 +1696,16 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *****Requires the script runs elevated*****
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the\hich\af2\dbch\af31505\loch\f2  script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 39 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 39 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Dev -ScriptInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptErrors_\hich\af2\dbch\af31505\loch\f2 yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text \hich\af2\dbch\af31505\loch\f2 file for transcript logging named
-\par \hich\af2\dbch\af31505\loch\f2     CVADDocScriptTranscript_yyyy-MM-dd_HHmm.txt.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 40 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -CSV
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendix.
-\par \hich\af2\dbch\af31505\loch\f2     For example:
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.c\hich\af2\dbch\af31505\loch\f2 sv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 41 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MaxDetails -HTML -MSWord -PDF -Text -Dev
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo -Log -CSV
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
@@ -1753,32 +1716,68 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
 \par \hich\af2\dbch\af31505\loch\f2     CVADDocScriptTranscript_yyyy-MM-dd_HHmm.txt.
 \par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 40 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1\hich\af2\dbch\af31505\loch\f2  -CSV
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendix.
 \par \hich\af2\dbch\af31505\loch\f2     For example:
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixA_VDARegistryI\hich\af2\dbch\af31505\loch\f2 tems.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixB_ControllerRegistry\hich\af2\dbch\af31505\loch\f2 Items.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_D\hich\af2\dbch\af31505\loch\f2 ocumentation_AppendixE_WindowsInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 41 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MaxDetails -HTML -MSWord -PDF -Text -Dev
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo -Log\hich\af2\dbch\af31505\loch\f2  -CSV
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVAD\hich\af2\dbch\af31505\loch\f2 InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
+\par \hich\af2\dbch\af31505\loch\f2     CVADDocScriptTranscript_yyyy-MM-dd_HHmm.txt.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendi\hich\af2\dbch\af31505\loch\f2 x.
+\par \hich\af2\dbch\af31505\loch\f2     For example:
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName\hich\af2\dbch\af31505\loch\f2 _Documentation_AppendixD_CitrixInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Microsoft Word and PDF, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \hich\af2\dbch\af31505\loch\f2 ses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offic\hich\af2\dbch\af31505\loch\f2 e\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administ\hich\af2\dbch\af31505\loch\f2 rator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
-\par \hich\af2\dbch\af31505\loch\f2         Administrators \hich\af2\dbch\af31505\loch\f2      = True
+\par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
 \par \hich\af2\dbch\af31505\loch\f2         Controllers         = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
-\par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
+\par \hich\af2\dbch\af31505\loch\f2         HardWar\hich\af2\dbch\af31505\loch\f2 e            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
@@ -1786,8 +1785,8 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
 \par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
-\par \hich\af2\dbch\af31505\loch\f2         S\hich\af2\dbch\af31505\loch\f2 ection             = "All"
+\par \hich\af2\dbch\af31505\loch\f2         NoPolicies       \hich\af2\dbch\af31505\loch\f2    = False
+\par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *****Requires the script runs elevated*****
@@ -1799,17 +1798,17 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 42 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -S\hich\af2\dbch\af31505\loch\f2 mtpServer mail.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     CVADAdmin@domain.tld -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from CVADAdmin@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sendi\hich\af2\dbch\af31505\loch\f2 ng from CVADAdmin@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 and}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send \hich\af2\dbch\af31505\loch\f2 email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the script prompts
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid cred\hich\af2\dbch\af31505\loch\f2 entials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1819,59 +1818,57 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 43 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_I\hich\af2\dbch\af31505\loch\f2 nventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending t\hich\af2\dbch\af31505\loch\f2 o ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated em\hich\af2\dbch\af31505\loch\f2 ail using an email relay server requires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 account}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956\hich\af2\dbch\af31505\loch\f2 491?hl=en" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
-\par \hich\af2\dbch\af31505\loch\f2     secure app access" o\hich\af2\dbch\af31505\loch\f2 ption on your account.
+\par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the Ad\hich\af2\dbch\af31505\loch\f2 minAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----\hich\af2\dbch\af31505\loch\f2 --------------------- EXAMPLE 44 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 44 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***O\hich\af2\dbch\af31505\loch\f2 FFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://docs.microsoft\hich\af2\dbch\af31505\loch\f2 
-.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-
+\hich\af2\dbch\af31505\loch\f2 a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}
 }}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
@@ -1882,9 +1879,9 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
 \par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Th\hich\af2\dbch\af31505\loch\f2 e script uses the default SMTP port 25 and SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML repor\hich\af2\dbch\af31505\loch\f2 t.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1892,11 +1889,11 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 45 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Sm\hich\af2\dbch\af31505\loch\f2 tpServer smtp.office365.com -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWe\hich\af2\dbch\af31505\loch\f2 bster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup\hich\af2\dbch\af31505\loch\f2 @carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
@@ -1907,15 +1904,15 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 46 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAM\hich\af2\dbch\af31505\loch\f2 PLE 46 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
-email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
-\hich\af2\dbch\af31505\loch\f2 the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+email using a Gmail or g-suite ac\hich\af2\dbch\af31505\loch\f2 count, you may have to turn ON}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
@@ -1929,10 +1926,10 @@ email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running\hich\af2\dbch\af31505\loch\f2  the script for the AdminAddress.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 RELATE\hich\af2\dbch\af31505\loch\f2 D LINKS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11345509\charrsid11345509 
+\par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11345509\charrsid11345509 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
 5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
@@ -2052,10 +2049,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e500000000000000000000000040ab
-f2e61ef3d60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000040abf2e61ef3d601
-40abf2e61ef3d60100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000040abf2e61ef3
-d60140abf2e61ef3d6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e50000000000000000000000008040
+d92827f7d60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff0200000000000000000000000000000000000000000000008040d92827f7d601
+8040d92827f7d60100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff0300000000000000000000000000000000000000000000008040d92827f7
+d6018040d92827f7d6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/CVAD_V3_Script_ChangeLog.txt
+++ b/CVAD_V3_Script_ChangeLog.txt
@@ -6,6 +6,13 @@
 
 # This script is based on the 2.36 script
 
+#Version 3.23 30-Jan-2021
+#	Added getting hardware information for the license server when -Hardware is used
+#	Added getting hardware information for the SQL Server(s) when -Hardware is used
+#	Fixed duplicate item in the HTML output for Machine Catalogs
+#	Fixed wrong variable name when getting the Monitoring database mirroring information
+#	Updated the WMI query code for getting the Power Plan to handle the case where the Power Plan data is missing in the WMI repository
+
 #Version 3.22 25-Jan-2021
 #	Added error checking in Function Check-NeededPSSnapins (Requested by Guy Leech)
 #	Updated Function ProcessScriptSetup to have standard error checking between the four XA/XD/CVAD/CC doc scripts


### PR DESCRIPTION
#Version 3.23 30-Jan-2021
#	Added getting hardware information for the license server when -Hardware is used
#	Added getting hardware information for the SQL Server(s) when -Hardware is used
#	Fixed duplicate item in the HTML output for Machine Catalogs
#	Fixed wrong variable name when getting the Monitoring database mirroring information
#	Updated the WMI query code for getting the Power Plan to handle the case where the Power Plan data is missing in the WMI repository