### PR TITLE
Final update for 3.24

### DIFF
--- a/CVAD_Inventory_V3_ReadMe.rtf
+++ b/CVAD_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -52,55 +52,53 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext22 \slink23 \styrsid16203271 header;}{\*\cs23 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedon10 \slink22 \slocked \styrsid16203271 
 Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \sbasedon0 \snext24 \slink25 \styrsid16203271 footer;}{\*\cs25 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedon10 \slink24 \slocked \styrsid16203271 Footer Char;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0
-\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4
-\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
-\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0
-\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0
-\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
-\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0
-\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0
-\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
-\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}
-{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid2071627316
-\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers
-;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
-\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 
-\fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname 
-;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid225408
-\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1575696\rsid1600787\rsid1654655\rsid1857973\rsid2054605\rsid2163600\rsid2191181\rsid2195246\rsid2243781\rsid2299277\rsid2517006\rsid2579094\rsid2584542
-\rsid2653562\rsid2902416\rsid2978753\rsid3097678\rsid3151791\rsid3300860\rsid3430394\rsid3505396\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4138244\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4462158\rsid4522193\rsid4740061\rsid4745200
-\rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5207971\rsid5209339\rsid5267713\rsid5339870\rsid5703879\rsid5728664\rsid5847035\rsid6053627\rsid6054960\rsid6058160\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6635878\rsid6637724\rsid6947370
-\rsid6966385\rsid7432229\rsid7560681\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828\rsid8662784\rsid8790405\rsid8876191\rsid9047498\rsid9112866\rsid9338186\rsid9376723\rsid9503154\rsid9520485\rsid9532820
-\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10303296\rsid10315109\rsid10488541\rsid10578344\rsid10580546\rsid10900280\rsid10963467\rsid10967884\rsid11041950\rsid11227030\rsid11345509\rsid11488686\rsid11605034\rsid11823514
-\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13270439\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13853169\rsid13966007
-\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14362273\rsid14577313\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid14964124\rsid15346731\rsid15405088\rsid15428007\rsid15613047\rsid15623927
-\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16017241\rsid16017738\rsid16085929\rsid16154053\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420
-\rsid16597410\rsid16669189\rsid16671705\rsid16713983}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2021\mo1\dy30\hr10\min44}{\version113}{\edmins11930}{\nofpages30}{\nofwords8815}{\nofchars50249}{\nofcharsws58947}{\vern15}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703
+\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703
+\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0
+\levelindent0{\leveltext\leveltemplateid2071627316\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
+{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
+\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
+\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid225408\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1575696\rsid1600787\rsid1654655
+\rsid1857973\rsid2054605\rsid2163600\rsid2191181\rsid2195246\rsid2243781\rsid2299277\rsid2517006\rsid2579094\rsid2584542\rsid2653562\rsid2902416\rsid2978753\rsid3097678\rsid3151791\rsid3300860\rsid3430394\rsid3505396\rsid3542051\rsid3760385\rsid3761251
+\rsid3830441\rsid4138244\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4462158\rsid4522193\rsid4740061\rsid4745200\rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5207971\rsid5209339\rsid5267713\rsid5339870\rsid5703879\rsid5728664\rsid5847035
+\rsid6053627\rsid6054960\rsid6058160\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6635878\rsid6637724\rsid6947370\rsid6966385\rsid7432229\rsid7560681\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828
+\rsid8662784\rsid8790405\rsid8876191\rsid9047498\rsid9112866\rsid9338186\rsid9376723\rsid9503154\rsid9520485\rsid9532820\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10303296\rsid10315109\rsid10488541\rsid10578344
+\rsid10580546\rsid10841649\rsid10900280\rsid10963467\rsid10967884\rsid11041950\rsid11227030\rsid11345509\rsid11488686\rsid11605034\rsid11823514\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12467537\rsid12523992\rsid12541957
+\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13270439\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13853169\rsid13966007\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14362273\rsid14577313
+\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid14964124\rsid15346731\rsid15405088\rsid15428007\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16017241
+\rsid16017738\rsid16085929\rsid16154053\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420\rsid16597410\rsid16669189\rsid16671705\rsid16713983}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
+\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo3\dy25\hr6\min12}{\version114}{\edmins11931}{\nofpages30}{\nofwords8815}{\nofchars50247}
+{\nofcharsws58945}{\vern21}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBUbmtQCMbrmoLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15346731 \chftnsep 
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBUYWtQBDciEvLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12467537 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15346731 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12467537 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15346731 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12467537 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15346731 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12467537 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid16203271 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 
@@ -211,8 +209,8 @@ Citrix Desktop Delivery Controller\\XDPoshSnapin_x??
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d000000009f009133000002000000000000450036410a00000041005e}}}{\fldrslt {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d000000009f009133000002000000000000450036410a00000041005e00}}}{\fldrslt 
+{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
@@ -342,23 +340,23 @@ re] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664
 \par \hich\af2\dbch\af31505\loch\f2     If you are running XA/XD 7.0 throug\hich\af2\dbch\af31505\loch\f2 h 7.7, please use:    }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030038}}
 }{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If you are running XA/XD 7.8 through CVAD 2006, please use:
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/xe\hich\af2\dbch\af31505\loch\f2 
-nappxendesktop-7-8/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/x\hich\af2\dbch\af31505\loch\f2 
+enappxendesktop-7-8/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030030}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If you are runni\hich\af2\dbch\af31505\loch\f2 ng Citrix Cloud, please use:    }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+\par \hich\af2\dbch\af31505\loch\f2     If you are runn\hich\af2\dbch\af31505\loch\f2 ing Citrix Cloud, please use:    }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be6000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
 64002d0069006e0066006f002f006300690074007200690078002d0063006c006f00750064002d006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d0073006500720076006900630065002f000000795881
-f43b1d7f48af2c825dc485276300000000a5ab000370}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+f43b1d7f48af2c825dc485276300000000a5ab00037043}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
 https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have at least Read access to the SQL
@@ -428,28 +426,28 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Localhost
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
+\par \hich\af2\dbch\af31505\loch\f2         Default val\hich\af2\dbch\af31505\loch\f2 ue                Localhost
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an.html extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a.txt exten\hich\af2\dbch\af31505\loch\f2 sion.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output form\hich\af2\dbch\af31505\loch\f2 at is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParam\hich\af2\dbch\af31505\loch\f2 eter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a.txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
@@ -457,52 +455,72 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Admins.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?  \hich\af2\dbch\af31505\loch\f2      false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Requi\hich\af2\dbch\af31505\loch\f2 red?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         G\hich\af2\dbch\af31505\loch\f2 ives detailed information for all applications.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value        \hich\af2\dbch\af31505\loch\f2         False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller section.
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 dds information on 315 registry keys to the Controller section.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         *****Requires the script runs\hich\af2\dbch\af31505\loch\f2  elevated*****
+\par \hich\af2\dbch\af31505\loch\f2         *****Requires the script runs elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
 \par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controller, to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BR\hich\af2\dbch\af31505\loch\f2 K.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    name\hich\af2\dbch\af31505\loch\f2 d
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Controllers [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Lists the following information to the Controllers section:
-\par \hich\af2\dbch\af31505\loch\f2                 Lis\hich\af2\dbch\af31505\loch\f2 t of installed Microsoft Hotfixes and Updates
+\par \hich\af2\dbch\af31505\loch\f2                 List of installed Microsoft Hotfixes and Updates
 \par \hich\af2\dbch\af31505\loch\f2                 List of Citrix installed components
 \par \hich\af2\dbch\af31505\loch\f2                 List of Windows installed Roles and Features
-\par \hich\af2\dbch\af31505\loch\f2                 Appendix C List of installed Microsoft Hotfixes and Updates for all
-\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    Controllers
+\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Appendix C List of installed Microsoft Hotfixes and Updates for all
+\par \hich\af2\dbch\af31505\loch\f2                 Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Appendix D List of Citrix installed components for all Controllers
-\par \hich\af2\dbch\af31505\loch\f2                 Appendix E List of Windows installed Roles and Features for all Controllers
+\par \hich\af2\dbch\af31505\loch\f2                 Appendix E List of Windows installed Roles and Feature\hich\af2\dbch\af31505\loch\f2 s for all Controllers
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This param\hich\af2\dbch\af31505\loch\f2 eter has an alias of DDC.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DDC.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
+\par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to r\hich\af2\dbch\af31505\loch\f2 etrieve hardware information (i.e. Domain Admin
+\par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         size of the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -510,31 +528,11 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
-\par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run fro\hich\af2\dbch\af31505\loch\f2 m an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
-\par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   size of the report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accep\hich\af2\dbch\af31505\loch\f2 t pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -DeliveryGroups [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information on all desktops in all Desktop (Delivery) Groups.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the\hich\af2\dbch\af31505\loch\f2  report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extre\hich\af2\dbch\af31505\loch\f2 mely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
 \par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
@@ -1109,8 +1107,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004f}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None. You cannot pipe objects to this script.
@@ -1118,17 +1116,16 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
-\par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, p\hich\af2\dbch\af31505\loch\f2 lain text, or HTML document.
+\par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, \hich\af2\dbch\af31505\loch\f2 plain text, or HTML document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: CVAD_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14964124 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10841649 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: January }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14964124 \hich\af2\dbch\af31505\loch\f2 30}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
-\hich\af2\dbch\af31505\loch\f2 , 2021
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10841649 \hich\af2\dbch\af31505\loch\f2 March 25, 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1163,8 +1160,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AdminAddress DDC01
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
-\par \hich\af2\dbch\af31505\loch\f2     DDC01 for the Adm\hich\af2\dbch\af31505\loch\f2 inAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML rep\hich\af2\dbch\af31505\loch\f2 ort by default.
+\par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1175,7 +1172,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1190,7 +1187,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Tex\hich\af2\dbch\af31505\loch\f2 t
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\CVAD_Inventory_V3.ps1 -Text
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Saves the document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1200,9 +1197,9 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -HTML
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Invento\hich\af2\dbch\af31505\loch\f2 ry_V3.ps1 -HTML
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Saves the document\hich\af2\dbch\af31505\loch\f2  as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     Saves the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1210,7 +1207,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1220,7 +1217,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V\hich\af2\dbch\af31505\loch\f2 3.ps1 -DeliveryGroups
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all desktops in all Desktop (Delivery)
 \par \hich\af2\dbch\af31505\loch\f2     Groups.
@@ -1229,19 +1226,19 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- \hich\af2\dbch\af31505\loch\f2 EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroupsUtilization -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroupsUtilization -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requires the use of MSWord or PDF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with utilization details for all Desktop (Delivery)
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with utilization details\hich\af2\dbch\af31505\loch\f2  for all Desktop (Delivery)
 \par \hich\af2\dbch\af31505\loch\f2     Groups.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1252,19 +1249,19 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 10 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroupsUtilization -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requires the use of MSWord or PDF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with utilization details for all Desktop (Deliver\hich\af2\dbch\af31505\loch\f2 y) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with utilization details f\hich\af2\dbch\af31505\loch\f2 or all Desktop (Delivery) Groups.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administra\hich\af2\dbch\af31505\loch\f2 tor
+\par \hich\af2\dbch\af31505\loch\f2     $en\hich\af2\dbch\af31505\loch\f2 v:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1278,8 +1275,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups -MachineCatalogs
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all machines in all Machine Catalogs and
-\par \hich\af2\dbch\af31505\loch\f2     all desktops i\hich\af2\dbch\af31505\loch\f2 n all Delivery Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details f\hich\af2\dbch\af31505\loch\f2 or all machines in all Machine Catalogs and
+\par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1287,9 +1284,9 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Applications
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3\hich\af2\dbch\af31505\loch\f2 .ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full detai\hich\af2\dbch\af31505\loch\f2 ls for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all applications.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1297,7 +1294,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Policies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for Policies.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1307,9 +1304,9 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -NoPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inven\hich\af2\dbch\af31505\loch\f2 tory_V3.ps1 -NoPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Crea\hich\af2\dbch\af31505\loch\f2 tes an HTML report with no Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with no Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1317,9 +1314,9 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 \hich\af2\dbch\af31505\loch\f2 -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTM\hich\af2\dbch\af31505\loch\f2 L report with no Citrix AD-based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with no Citrix AD-based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1327,30 +1324,30 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -Policies -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Policies -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on Site policies created in Studio but
-\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD-based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD-based Policy inf\hich\af2\dbch\af31505\loch\f2 ormation.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 17 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Administrators
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on Admi\hich\af2\dbch\af31505\loch\f2 nistrator Scopes and Roles.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -------------------------- EXAMPLE 18 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Logging -StartDate 09/01/2021 -EndDate
-\par \hich\af2\dbch\af31505\loch\f2     09/30/2021
+\par \hich\af2\dbch\af31505\loch\f2     09/30/20\hich\af2\dbch\af31505\loch\f2 21
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with Configuration Logging details for the dates 09/01/2021
 \par \hich\af2\dbch\af31505\loch\f2     through 09/30/2021.
@@ -1362,22 +1359,22 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Logging -StartDate "09/01/2021 10:00:00"
-\par \hich\af2\dbch\af31505\loch\f2     -EndDate "\hich\af2\dbch\af31505\loch\f2 09/01/2021 14:00:00" -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     -EndDate "09/01/2021 14:00:00" -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with Configuration Logging details for the time range
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with Configuration L\hich\af2\dbch\af31505\loch\f2 ogging details for the time range
 \par \hich\af2\dbch\af31505\loch\f2     09/01/2021 10:00:00AM through 09/01/2021 02:00:00PM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either\hich\af2\dbch\af31505\loch\f2  00 or 59.
+\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offi\hich\af2\dbch\af31505\loch\f2 ce\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administra\hich\af2\dbch\af31505\loch\f2 tor
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1388,28 +1385,28 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Hosting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for Hosts, Host Connections, and Resources.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the\hich\af2\dbch\af31505\loch\f2  AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -StoreFront
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventor\hich\af2\dbch\af31505\loch\f2 y_V3.ps1 -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for StoreFront.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the Admin\hich\af2\dbch\af31505\loch\f2 Address.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MachineCatalogs -DeliveryGroups
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.p\hich\af2\dbch\af31505\loch\f2 s1 -MachineCatalogs -DeliveryGroups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications -Policies -Hosting -StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details \hich\af2\dbch\af31505\loch\f2 for all:
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
@@ -1424,20 +1421,20 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MC -DG -Apps -Policies -Hosting -PDF
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript \hich\af2\dbch\af31505\loch\f2 >.\\CVAD_Inventory_V3.ps1 -MC -DG -Apps -Policies -Hosting -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with full detail\hich\af2\dbch\af31505\loch\f2 s for all:
+\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
-\par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
+\par \hich\af2\dbch\af31505\loch\f2         Hosts, Host C\hich\af2\dbch\af31505\loch\f2 onnections, and Resources
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\C\hich\af2\dbch\af31505\loch\f2 ommon\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:userna\hich\af2\dbch\af31505\loch\f2 me = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1449,10 +1446,10 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps\hich\af2\dbch\af31505\loch\f2 1 -MSWord -CompanyName "Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft\hich\af2\dbch\af31505\loch\f2  Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
@@ -1469,7 +1466,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias \hich\af2\dbch\af31505\loch\f2 CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
@@ -1479,49 +1476,49 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName\hich\af2\dbch\af31505\loch\f2  "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker
-\par \hich\af2\dbch\af31505\loch\f2     Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
+\par \hich\af2\dbch\af31505\loch\f2     Street, \hich\af2\dbch\af31505\loch\f2 London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Sher\hich\af2\dbch\af31505\loch\f2 lock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the U\hich\af2\dbch\af31505\loch\f2 ser Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753\hich\af2\dbch\af31505\loch\f2  276200 for the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail
 \par \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the \hich\af2\dbch\af31505\loch\f2 Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAM\hich\af2\dbch\af31505\loch\f2 PLE 28 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVA\hich\af2\dbch\af31505\loch\f2 D_Inventory_V3.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM \hich\af2\dbch\af31505\loch\f2 is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName_2021-06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName\hich\af2\dbch\af31505\loch\f2 _2021-06-01_1800.docx
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1533,19 +1530,19 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values and saves the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Co\hich\af2\dbch\af31505\loch\f2 mpany="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover P\hich\af2\dbch\af31505\loch\f2 age format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the\hich\af2\dbch\af31505\loch\f2  format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName_2021-06-01\hich\af2\dbch\af31505\loch\f2 _1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be CVADSiteName_2021-06-01_1800.pdf
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1555,7 +1552,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Hardware
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with hardware information for th\hich\af2\dbch\af31505\loch\f2 e Controllers.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with hardware information for the Controllers.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1567,17 +1564,17 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     Output file is saved in the path \\\\FileServer\\ShareName
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer runni\hich\af2\dbch\af31505\loch\f2 ng the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory\hich\af2\dbch\af31505\loch\f2 _V3.ps1 -Section Policies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report that contains only policy information.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
+\par \hich\af2\dbch\af31505\loch\f2     Processes onl\hich\af2\dbch\af31505\loch\f2 y the Policies section of the report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1589,31 +1586,31 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with Delivery Group details.
-\par \hich\af2\dbch\af31505\loch\f2     The compu\hich\af2\dbch\af31505\loch\f2 ter running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 34 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Groups
+\par \hich\af2\dbch\af31505\loch\f2     PS\hich\af2\dbch\af31505\loch\f2  C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Section Groups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section o\hich\af2\dbch\af31505\loch\f2 f the report with no Delivery Group details.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with no Delivery Group details.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 35 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------------\hich\af2\dbch\af31505\loch\f2 ------------ EXAMPLE 35 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -BrokerRegistryKeys
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an\hich\af2\dbch\af31505\loch\f2  HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *****Requires the script runs elevated*****
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds the information on over 300 Broker registry keys to the Controllers section.
+\par \hich\af2\dbch\af31505\loch\f2     Adds the information on over 300 Broker registry keys to \hich\af2\dbch\af31505\loch\f2 the Controllers section.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1624,7 +1621,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -VDARegistryKeys
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Adds the information on VDA re\hich\af2\dbch\af31505\loch\f2 gistry keys to Appendix A.
+\par \hich\af2\dbch\af31505\loch\f2     Adds the information on VDA registry keys to Appendix A.
 \par \hich\af2\dbch\af31505\loch\f2     Forces the MachineCatalogs parameter to $True
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1633,15 +1630,15 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 37 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Ma\hich\af2\dbch\af31505\loch\f2 xDetails
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
 \par \hich\af2\dbch\af31505\loch\f2         Controllers         = True
-\par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
-\par \hich\af2\dbch\af31505\loch\f2         HardWare            = T\hich\af2\dbch\af31505\loch\f2 rue
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     DeliveryGroups      = True
+\par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
@@ -1655,7 +1652,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     *****Requires the script runs elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script\hich\af2\dbch\af31505\loch\f2  for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1666,14 +1663,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     For Microsoft Word and PDF, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
-\hich\af2\dbch\af31505\loch\f2 ses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     For\hich\af2\dbch\af31505\loch\f2  Microsoft Word and PDF, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 ses all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = A\hich\af2\dbch\af31505\loch\f2 dministrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webs\hich\af2\dbch\af31505\loch\f2 ter for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1681,14 +1678,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Controllers         = True
+\par \hich\af2\dbch\af31505\loch\f2         Controllers         = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
-\par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
+\par \hich\af2\dbch\af31505\loch\f2         Mac\hich\af2\dbch\af31505\loch\f2 hineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
-\par \hich\af2\dbch\af31505\loch\f2         StoreFront\hich\af2\dbch\af31505\loch\f2           = True
+\par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
 \par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
@@ -1696,12 +1693,12 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *****Requires the script runs elevated*****
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 39 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 39 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Dev -ScriptInfo -Log
 \par 
@@ -1739,57 +1736,57 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 41 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MaxDetails -HTML -MSWord -PDF -Text -Dev
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo -Log\hich\af2\dbch\af31505\loch\f2  -CSV
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo -Log -CSV
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Creates a text file named CVADInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVAD\hich\af2\dbch\af31505\loch\f2 InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named CVADInventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script paramet\hich\af2\dbch\af31505\loch\f2 ers and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
 \par \hich\af2\dbch\af31505\loch\f2     CVADDocScriptTranscript_yyyy-MM-dd_HHmm.txt.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendi\hich\af2\dbch\af31505\loch\f2 x.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendix.
 \par \hich\af2\dbch\af31505\loch\f2     For example:
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixA_VDARegistryItem\hich\af2\dbch\af31505\loch\f2 s.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.csv
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName\hich\af2\dbch\af31505\loch\f2 _Documentation_AppendixD_CitrixInstalledComponents.csv
-\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Docu\hich\af2\dbch\af31505\loch\f2 mentation_AppendixE_WindowsInstalledComponents.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Microsoft Word and PDF, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \hich\af2\dbch\af31505\loch\f2 ses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administ\hich\af2\dbch\af31505\loch\f2 rator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
-\par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
+\par \hich\af2\dbch\af31505\loch\f2         Administra\hich\af2\dbch\af31505\loch\f2 tors      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
 \par \hich\af2\dbch\af31505\loch\f2         Controllers         = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
-\par \hich\af2\dbch\af31505\loch\f2         HardWar\hich\af2\dbch\af31505\loch\f2 e            = True
+\par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
-\par \hich\af2\dbch\af31505\loch\f2         Logging             = True
+\par \hich\af2\dbch\af31505\loch\f2         Logging             =\hich\af2\dbch\af31505\loch\f2  True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
 \par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         NoPolicies       \hich\af2\dbch\af31505\loch\f2    = False
+\par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
 \par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     *****Requires the script runs elevated*****
+\par \hich\af2\dbch\af31505\loch\f2     *****Requires the script runs e\hich\af2\dbch\af31505\loch\f2 levated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1798,20 +1795,20 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 42 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     CVADAdmin@domain.tld -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sendi\hich\af2\dbch\af31505\loch\f2 ng from CVADAdmin@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from CVADAdmin@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 and}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses th\hich\af2\dbch\af31505\loch\f2 e default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid cred\hich\af2\dbch\af31505\loch\f2 entials.
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddre\hich\af2\dbch\af31505\loch\f2 ss.
 \par 
 \par 
 \par 
@@ -1826,49 +1823,50 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mailrelay.domain.tld, sending from
 \par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated em\hich\af2\dbch\af31505\loch\f2 ail using an email relay server requires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From\hich\af2\dbch\af31505\loch\f2  email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 account}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956\hich\af2\dbch\af31505\loch\f2 491?hl=en" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5728664 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
-\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the Ad\hich\af2\dbch\af31505\loch\f2 minAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 44 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EX\hich\af2\dbch\af31505\loch\f2 AMPLE 44 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-
-\hich\af2\dbch\af31505\loch\f2 a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-offi\hich\af2\dbch\af31505\loch\f2 ce-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}
 }}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 
 \par 
@@ -1876,13 +1874,13 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email\hich\af2\dbch\af31505\loch\f2  server labaddomain-com.mail.protection.outlook.com, sending
 \par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML repor\hich\af2\dbch\af31505\loch\f2 t.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running th\hich\af2\dbch\af31505\loch\f2 e script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1890,7 +1888,7 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 45 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWe\hich\af2\dbch\af31505\loch\f2 bster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebs\hich\af2\dbch\af31505\loch\f2 ter.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
@@ -1919,14 +1917,14 @@ email using a Gmail or g-suite ac\hich\af2\dbch\af31505\loch\f2 count, you may h
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 webster@gmail.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2 
- and s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 endin\hich\af2\dbch\af31505\loch\f2 g to ITGroup@carlwebster.com.
+ and s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 ending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 the script prompts the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5728664\charrsid5728664 \hich\af2\dbch\af31505\loch\f2 user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running\hich\af2\dbch\af31505\loch\f2  the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11345509\charrsid11345509 
@@ -2049,10 +2047,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e50000000000000000000000008040
-d92827f7d60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff0200000000000000000000000000000000000000000000008040d92827f7d601
-8040d92827f7d60100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff0300000000000000000000000000000000000000000000008040d92827f7
-d6018040d92827f7d6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e500000000000000000000000030ac
+a7c46721d70103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000030aca7c46721d701
+30aca7c46721d70100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000030aca7c46721
+d70130aca7c46721d7010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/CVAD_V3_Script_ChangeLog.txt
+++ b/CVAD_V3_Script_ChangeLog.txt
@@ -6,6 +6,25 @@
 
 # This script is based on the 2.36 script
 
+#Version 3.24 25-Mar-2021 (20 years of Dave Ramsey)
+#	Added Computer policy
+#		Profile Management\Enable profile streaming for folders
+#		Workspace Environment Management\Citrix Cloud Connectors
+#	Added Server VDA Registry Key:
+#		HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Explorer.exe\DontUseDesktopChangeRouter
+#	Added User policy
+#		ICA\Multimedia\Browser Content Redirection Server Fetch Proxy Auth
+#	Fixed one @XDParams1 that I missed and changed it to @CVADParams1
+#		This made the Monitoring Database Details and Groom Retention Settings in Days always show as Disabled
+#	For 2103 Restart schedules, added the following items:
+#		Use natural reboot
+#		Ignore maintenance mode
+#		Maximum Overtime Start Minutes
+#	Renamed computer policy
+#		Enable multi-session write-back for FSLogix Profile Container to Enable multi-session write-back for profile containers
+#		Virtual channel white list to Virtual channel allow list
+#	Updated for CVAD 2103/7.29
+
 #Version 3.23 30-Jan-2021
 #	Added getting hardware information for the license server when -Hardware is used
 #	Added getting hardware information for the SQL Server(s) when -Hardware is used


### PR DESCRIPTION
#Version 3.24 25-Mar-2021 (20 years of Dave Ramsey)
#	Added Computer policy
#		Profile Management\Enable profile streaming for folders
#		Workspace Environment Management\Citrix Cloud Connectors
#	Added Server VDA Registry Key:
#		HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Explorer.exe\DontUseDesktopChangeRouter
#	Added User policy
#		ICA\Multimedia\Browser Content Redirection Server Fetch Proxy Auth
#	Fixed one @XDParams1 that I missed and changed it to @CVADParams1
#		This made the Monitoring Database Details and Groom Retention Settings in Days always show as Disabled
#	For 2103 Restart schedules, added the following items:
#		Use natural reboot
#		Ignore maintenance mode
#		Maximum Overtime Start Minutes
#	Renamed computer policy
#		Enable multi-session write-back for FSLogix Profile Container to Enable multi-session write-back for profile containers
#		Virtual channel white list to Virtual channel allow list
#	Updated for CVAD 2103/7.29