### PR TITLE
Final update for 3.32

### DIFF
--- a/CVAD_Inventory_V3_ReadMe.rtf
+++ b/CVAD_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -84,22 +84,22 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \rsid5207971\rsid5209339\rsid5267713\rsid5339870\rsid5460787\rsid5703879\rsid5728664\rsid5847035\rsid6053627\rsid6054960\rsid6058160\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6635878\rsid6637724\rsid6819877\rsid6947370\rsid6966385\rsid7091148
 \rsid7097660\rsid7233217\rsid7432229\rsid7560681\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828\rsid8662784\rsid8790405\rsid8876191\rsid8913570\rsid9047498\rsid9112866\rsid9338186\rsid9376723\rsid9503154
 \rsid9520485\rsid9532820\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10303296\rsid10315109\rsid10488541\rsid10578344\rsid10580546\rsid10775101\rsid10841649\rsid10900280\rsid10963467\rsid10967884\rsid11041950\rsid11227030
-\rsid11345509\rsid11488686\rsid11605034\rsid11823514\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12277571\rsid12353294\rsid12467537\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13270439
-\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13767035\rsid13853169\rsid13966007\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14362273\rsid14382587\rsid14577313\rsid14684132\rsid14697282\rsid14828264\rsid14881286
-\rsid14888064\rsid14962568\rsid14964124\rsid15346731\rsid15405088\rsid15428007\rsid15613047\rsid15623927\rsid15667239\rsid15678052\rsid15692337\rsid15739384\rsid15797907\rsid15802422\rsid15873118\rsid15877015\rsid15948729\rsid16017241\rsid16017738
-\rsid16085929\rsid16154053\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420\rsid16529279\rsid16597410\rsid16669189\rsid16671705\rsid16713983}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
-\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo12\dy24\hr11\min5}{\version125}{\edmins11945}{\nofpages29}{\nofwords8854}
-{\nofchars50469}{\nofcharsws59205}{\vern39}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid11345509\rsid11488686\rsid11605034\rsid11823514\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12277571\rsid12353294\rsid12403800\rsid12467537\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708
+\rsid13270439\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13704504\rsid13767035\rsid13853169\rsid13966007\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14362273\rsid14382587\rsid14577313\rsid14684132\rsid14697282
+\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid14964124\rsid15346731\rsid15405088\rsid15428007\rsid15613047\rsid15623927\rsid15667239\rsid15678052\rsid15692337\rsid15739384\rsid15797907\rsid15802422\rsid15873118\rsid15877015\rsid15948729
+\rsid16017241\rsid16017738\rsid16085929\rsid16154053\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420\rsid16529279\rsid16597410\rsid16669189\rsid16671705\rsid16713983}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2022\mo2\dy15\hr14}{\version126}{\edmins11946}{\nofpages29}
+{\nofwords8854}{\nofchars50469}{\nofcharsws59205}{\vern41}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBcamtQA5Zk2bLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15667239 \chftnsep 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12403800 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15667239 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12403800 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15667239 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12403800 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15667239 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12403800 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid16203271 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 
@@ -117,7 +117,7 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid11345509 \hich\af43\dbch\af31505\loch\f43 English}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
 \hich\af43\dbch\af31505\loch\f43  Versions of Microsoft Word
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 The script supports the following langua\hich\af37\dbch\af31505\loch\f37 ges:
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 The script supports the following l\hich\af37\dbch\af31505\loch\f37 anguages:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls1\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Catalan}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
@@ -310,7 +310,7 @@ ng>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/" }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003f8}}
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003f800}}
 }{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
 \par 
@@ -318,22 +318,22 @@ ng>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid7091148 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000387}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00038700}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid7091148\charrsid7091148 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If you are running Citrix Cloud, please use:
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-
-\hich\af2\dbch\af31505\loch\f2 and-desktops-service/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
+\hich\af2\dbch\af31505\loch\f2 -and-desktops-service/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be6000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
 64002d0069006e0066006f002f006300690074007200690078002d0063006c006f00750064002d006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d0073006500720076006900630065002f000000795881
-f43b1d7f48af2c825dc485276300000000a5ab0003b7}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-clou
-\hich\af2\dbch\af31505\loch\f2 d-citrix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
+f43b1d7f48af2c825dc485276300000000a5ab0003b700}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-clo
+\hich\af2\dbch\af31505\loch\f2 ud-citrix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have at least Read access to the SQL
 \par \hich\af2\dbch\af31505\loch\f2     Server(s) that hold(s) the Citrix Site, Monitoring, and Logging databases.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary infor\hich\af2\dbch\af31505\loch\f2 mation for:
+\par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary info\hich\af2\dbch\af31505\loch\f2 rmation for:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         App-V Publishing
 \par \hich\af2\dbch\af31505\loch\f2         Application Groups
@@ -345,7 +345,7 @@ f43b1d7f48af2c825dc485276300000000a5ab0003b7}}}{\fldrslt {\rtlch\fcs1 \af2\afs18
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
-\par \hich\af2\dbch\af31505\loch\f2         Zon\hich\af2\dbch\af31505\loch\f2 es
+\par \hich\af2\dbch\af31505\loch\f2         Zo\hich\af2\dbch\af31505\loch\f2 nes
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
@@ -470,28 +470,28 @@ f43b1d7f48af2c825dc485276300000000a5ab0003b7}}}{\fldrslt {\rtlch\fcs1 \af2\afs18
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on 360 registry keys to the Controller \hich\af2\dbch\af31505\loch\f2 section.
+\par \hich\af2\dbch\af31505\loch\f2         Adds informa\hich\af2\dbch\af31505\loch\f2 tion on 360 registry keys to the Controller section.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         *****Requires the script runs elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
-\par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controller, to the report.
+\par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controlle\hich\af2\dbch\af31505\loch\f2 r, to the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is\hich\af2\dbch\af31505\loch\f2  disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wi\hich\af2\dbch\af31505\loch\f2 ldcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Controllers [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Lists the following information to the Controllers section:
@@ -552,11 +552,11 @@ f43b1d7f48af2c825dc485276300000000a5ab0003b7}}}{\fldrslt {\rtlch\fcs1 \af2\afs18
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Gives a chart with the delivery group utilization for the last 7 days
 \par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
-\par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be local\hich\af2\dbch\af31505\loch\f2 ly installed.
+\par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be locall\hich\af2\dbch\af31505\loch\f2 y installed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
@@ -564,21 +564,21 @@ f43b1d7f48af2c825dc485276300000000a5ab0003b7}}}{\fldrslt {\rtlch\fcs1 \af2\afs18
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gi\hich\af2\dbch\af31505\loch\f2 ve detailed information for Hosts, Host Connections, and Resources.
+\par \hich\af2\dbch\af31505\loch\f2         Giv\hich\af2\dbch\af31505\loch\f2 e detailed information for Hosts, Host Connections, and Resources.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -1103,10 +1103,10 @@ f43b1d7f48af2c825dc485276300000000a5ab0003b7}}}{\fldrslt {\rtlch\fcs1 \af2\afs18
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, \hich\af2\dbch\af31505\loch\f2 WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15877015 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15877015 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15877015 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15877015 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid15877015 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid15877015 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
@@ -1114,7 +1114,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are o\hich\af2\dbch\af31505\loch\f2 utput from this script.
 \par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, plain text, or HTML document.
 \par 
 \par 
@@ -1122,36 +1122,35 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: CVAD_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15877015 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: C\hich\af2\dbch\af31505\loch\f2 arl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15877015 \hich\af2\dbch\af31505\loch\f2 December}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
-\hich\af2\dbch\af31505\loch\f2  2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15877015 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 , 2021
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13704504 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13704504 \hich\af2\dbch\af31505\loch\f2 February 15, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddre\hich\af2\dbch\af31505\loch\f2 ss.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------------\hich\af2\dbch\af31505\loch\f2 -------------- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\S\hich\af2\dbch\af31505\loch\f2 oftware\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1160,8 +1159,8 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AdminAddress DDC01
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Cre\hich\af2\dbch\af31505\loch\f2 ates an HTML report by default.
-\par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
+\par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAd\hich\af2\dbch\af31505\loch\f2 dress.
 \par 
 \par 
 \par 
@@ -1432,13 +1431,13 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer r\hich\af2\dbch\af31505\loch\f2 unning the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer runni\hich\af2\dbch\af31505\loch\f2 ng the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1446,7 +1445,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster"\hich\af2\dbch\af31505\loch\f2  -AdminAddress DDC01
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -Ad\hich\af2\dbch\af31505\loch\f2 minAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
@@ -1465,7 +1464,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Carl W\hich\af2\dbch\af31505\loch\f2 ebster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webs\hich\af2\dbch\af31505\loch\f2 ter Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
@@ -1473,11 +1472,11 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE\hich\af2\dbch\af31505\loch\f2  26 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26\hich\af2\dbch\af31505\loch\f2  --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript.\\CVAD_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker
-\par \hich\af2\dbch\af31505\loch\f2     Street, London, England" -CompanyFax "+44 175\hich\af2\dbch\af31505\loch\f2 3 276600" -CompanyPhone "+44 1753 276200"
+\par \hich\af2\dbch\af31505\loch\f2     Street, London, England" -CompanyFax "+44 1753 2\hich\af2\dbch\af31505\loch\f2 76600" -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
@@ -1828,17 +1827,17 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid7091148 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000380}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00038000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid7091148 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "\hich\af2\dbch\af31505\loch\f2 Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
-\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP\hich\af2\dbch\af31505\loch\f2  RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
@@ -1853,24 +1852,23 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
-\par \hich\af2\dbch\af31505\loch\f2     S\hich\af2\dbch\af31505\loch\f2 omeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 
-{\*\datafield 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000302}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exc\hich\af2\dbch\af31505\loch\f2 
-hange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030200}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-\hich\af2\dbch\af31505\loch\f2 
+device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protect\hich\af2\dbch\af31505\loch\f2 ion.outlook.com, sending
-\par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
+\par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomai\hich\af2\dbch\af31505\loch\f2 n.com and sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
 \par 
@@ -1885,11 +1883,11 @@ hange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-applicati
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the e\hich\af2\dbch\af31505\loch\f2 mail server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid cre\hich\af2\dbch\af31505\loch\f2 dentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user'\hich\af2\dbch\af31505\loch\f2 s credentials are not valid to send an email, the script prompts
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1903,15 +1901,15 @@ hange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-applicati
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7091148\charrsid7091148 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to \hich\af2\dbch\af31505\loch\f2 turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the script prompts t\hich\af2\dbch\af31505\loch\f2 he
-\par \hich\af2\dbch\af31505\loch\f2     user to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the script prompts the
+\par \hich\af2\dbch\af31505\loch\f2     user to ent\hich\af2\dbch\af31505\loch\f2 er valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -2039,10 +2037,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e500000000000000000000000050fc
-c780e8f8d70103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000050fcc780e8f8d701
-50fcc780e8f8d70100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000050fcc780e8f8
-d70150fcc780e8f8d7010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e50000000000000000000000006083
+33b4a622d80103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000608333b4a622d801
+608333b4a622d80100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000608333b4a622
+d801608333b4a622d8010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/CVAD_V3_Script_ChangeLog.txt
+++ b/CVAD_V3_Script_ChangeLog.txt
@@ -6,6 +6,23 @@
 
 # This script is based on the 2.36 script
 
+#Version 3.32 15-Feb-2022
+#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
+#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
+#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
+#		For example: 20221225T0840107271.
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 3.31 24-Dec-2021
 #	Added Broker Registry Keys:
 #		HKLM:\Software\Policies\Citrix\DesktopServer\LaunchCheckFaultStates


### PR DESCRIPTION
#Version 3.32 15-Feb-2022
#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
#		For example: 20221225T0840107271.
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#		Added stopping the transcript log if the log was enabled and started
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
#	Updated the help text
#	Updated the ReadMe file