### PR TITLE
Final update for 3.39

### DIFF
--- a/CVAD_Inventory_V3.ps1
+++ b/CVAD_Inventory_V3.ps1
@@ -1052,9 +1052,9 @@
 	This script creates a Word, PDF, plain text, or HTML document.
 .NOTES
 	NAME: CVAD_Inventory_V3.ps1
-	VERSION: 3.38
+	VERSION: 3.39
 	AUTHOR: Carl Webster
-	LASTEDIT: October 2, 2022
+	LASTEDIT: January 6, 2023
 #>
 
 #endregion
@@ -1248,6 +1248,36 @@ Param(
 # This script is based on the 2.36 script
 #
 
+#Version 3.39 6-Jan-2023
+#	Added to Function OutputMachines, the Catalog's reboot schedule if one exists
+#		https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/install-configure/machine-catalogs-manage.html#update-the-catalog
+#	For Provisioning Custom Properties, added two Azure properties I hadn't noticed before:
+#		https://developer-docs.citrix.com/projects/citrix-virtual-apps-desktops-sdk/en/latest/MachineCreation/about_Prov_CustomProperties/
+#		PageFileDiskDriveLetterOverride
+#		StorageTypeAtShutdown
+#	In Function GetRolePermissions:
+#		Added new permissions
+#			AppLib_PackageDiscovery_Create
+#			AppLib_PackageDiscoveryProfile_Create
+#			AppLib_PackageDiscoveryProfile_Remove
+#			DesktopGroup_CreateFolder
+#			DesktopGroup_EditFolder
+#			DesktopGroup_MoveFolder
+#			DesktopGroup_RemoveFolder
+#			Catalog_CreateFolder
+#			Catalog_EditFolder
+#			Catalog_MoveFolder
+#			Catalog_RemoveFolder
+#			PolicySets_AddScope
+#           PolicySets_Manage
+#           PolicySets_Read
+#           PolicySets_RemoveScope
+#           Setting_Edit
+#			Setting_Read
+#	In Function OutputMachineDetails, fixed the missing $WillShutdownAfterUseReason variable
+#	In Function OutputMachines, fixed the misplaced code for image history and additional data
+#	Updated for CVAD 2209/7.35 and CVAD 2212/7.36
+#
 #Version 3.38 2-Oct-2022
 #	Added Computer policy
 #		Profile Management\Advanced settings\Maximum number of VHDX disks for storing Outlook OST files
@@ -2009,9 +2039,9 @@ $SaveEAPreference         = $ErrorActionPreference
 $ErrorActionPreference    = 'SilentlyContinue'
 
 #stuff for report footer
-$script:MyVersion   = '3.38'
+$script:MyVersion   = '3.39'
 $Script:ScriptName  = "CVAD_Inventory_V3.ps1"
-$tmpdate            = [datetime] "10/02/2022"
+$tmpdate            = [datetime] "01/06/2022"
 $Script:ReleaseDate = $tmpdate.ToUniversalTime().ToShortDateString()
 
 If($Null -eq $HTML)
@@ -6737,7 +6767,7 @@ Function GetAdmins
 		"ApplicationGroup" {
 			$scopes = $Null
 
-			$permissions = Get-AdminPermission @CCParams2 | `
+			$permissions = Get-AdminPermission @CVADParams2 | `
 			Where-Object { $_.MetadataMap["Citrix_ObjectType"] -eq "ApplicationGroup"} | `
 			Select-Object -ExpandProperty Id
 
@@ -8223,6 +8253,7 @@ Function OutputMachines
 					MaxPageFileSizeInMB
 					OsType
 					PageFileDiskDriveLetter
+					PageFileDiskDriveLetterOverride $new in 2212
 					PersistOsDisk
 					PersistVm
 					PersistWBC
@@ -8234,6 +8265,7 @@ Function OutputMachines
 					StorageAccountsPerResourceGroup
 					StorageAccountType
 					StorageType
+					StorageTypeAtShutdown #new in 2212
 					UseEphemeralOsDisk
 					UseManagedDisks
 					UseSharedImageGallery
@@ -8255,7 +8287,7 @@ Function OutputMachines
 					WBCDiskStorageType
 			#>
 			
-			$ProvScheme = Get-ProvScheme -ProvisioningSchemeUid $Catalog.ProvisioningSchemeID @CCParams2
+			$ProvScheme = Get-ProvScheme -ProvisioningSchemeUid $Catalog.ProvisioningSchemeID @CVADParams2
 			
 			If(!$? -or $Null -eq $ProvScheme)
 			{
@@ -8391,7 +8423,7 @@ Function OutputMachines
 								-ProvisioningSchemeUid $Catalog.ProvisioningSchemeID `
 								-ShowAll `
 								-SortBy 'provisioningschemename,date' `
-								@CCParams2
+								@CVADParams2
 				
 				If($? -and $Null -eq $ImageHistory)
 				{
@@ -8494,6 +8526,139 @@ Function OutputMachines
 							FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "700"
 							WriteHTMLLine 0 0 ""
 						}
+
+						<#
+						ProvisioningSchemeName : JCW-OnPrem-Win10
+						Date                   : 10/5/2021 10:36:59 AM
+						MasterImageVM          : XDHyp:\HostingUnits\WebstersLab\CVD-CC-BUILD-05102021-1718.vm\CVD-CC-BUILD-05102021-1732.snapshot
+						MasterImageNote        :
+						FunctionalLevel        : L7_30
+						ImageStatus            : Current
+						#>
+						
+						#Additional Data - added in 3.35
+						Write-Verbose "$(Get-Date -Format G): `t`t`tAdding catalog additional data (if any)"
+						
+						#The AdditionalData property is a hashtable and is neither null nor empty. 
+						#If there is nothing in the hashtable, the count value is 0
+						try
+						{
+							If(Test-Path $Image.MasterImageVM 4>$Null)
+							{
+								$TmpData = Get-Item $Image.MasterImageVM -ea 0 4>$Null
+
+								If($? -and (validObject $TmpData AdditionalData))
+								{
+									$AdditionalData = $TmpData.AdditionalData
+								}
+								Else
+								{
+									$AdditionalData = @{}
+								}
+							}
+							Else
+							{
+								$AdditionalData = @{}
+							}
+						}
+						
+						catch
+						{
+							$AdditionalData = @{}
+						}
+						
+						If($AdditionalData.Count -eq 0)
+						{
+							#There is no additional data, so nothing to do
+						}
+						ElseIf($AdditionalData.Count -gt 0)
+						{
+							If($MSWord -or $PDF)
+							{
+								WriteWordLine 4 0 "Additional Data"
+								$AdditionalDataWordTable = @()
+							}
+							If($Text)
+							{
+								Line 1 "Additional Data"
+
+								Line 2 'Additional Property Name                  Value                    '
+								Line 2 '==================================================================='
+								#       ServiceOfferingWithTemporaryDiskSizeInMbSS1234567890123456789012345
+								#       1234567890123456789012345678901234567890
+							}
+							If($HTML)
+							{
+								WriteHTMLLine 4 0 "Additional Data"
+								$rowdata = @()
+							}
+
+							ForEach($Item in $AdditionalData.Keys)
+							{
+								If($MSWord -or $PDF)
+								{
+									$AdditionalDataWordTable += @{ 
+										PropertyName  = $Item;
+										PropertyValue = $AdditionalData.$Item;
+									}
+								}
+								If($Text)
+								{
+									Line 2 ( "{0,-40}  {1,-25}" -f $Item, $AdditionalData.$Item )
+								}
+								If($HTML)
+								{
+									$rowdata += @(,(
+										$Item,$htmlwhite,
+										$AdditionalData.$Item,$htmlwhite)
+									)
+								}
+							}
+							
+							If($MSWord -or $PDF)
+							{
+								If($AdditionalDataWordTable.Count -eq 0)
+								{
+									$AdditionalDataWordTable += @{ 
+										PropertyName  = "None found";
+										PropertyValue = "";
+									}
+								}
+								
+								$Table = AddWordTable -Hashtable $AdditionalDataWordTable `
+								-Columns PropertyName, PropertyValue `
+								-Headers "Additional Property Name", "Value" `
+								-Format $wdTableGrid `
+								-AutoFit $wdAutoFitContent;
+
+								SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+								$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+
+								FindWordDocumentEnd
+								$Table = $Null
+								WriteWordLine 0 0 ""
+							}
+							If($Text)
+							{
+								Line 0 ""
+							}
+							If($HTML)
+							{
+								$columnHeaders = @(
+									'Additional Property Name',($global:htmlsb),
+									'Value',($global:htmlsb)
+								)
+
+								$msg = ""
+								FormatHTMLTable $msg "auto" -rowArray $rowdata -columnArray $columnHeaders
+								WriteHTMLLine 0 0 ""
+							}
+						}
+						Else
+						{
+							#Could not retrieve additional data, so nothing to do
+						}
 					}
 				}
 				Else
@@ -8501,112 +8666,74 @@ Function OutputMachines
 					$txt = "Unable to retrieve Image History for Machine Catalog $($Catalog.CatalogName) Provisioning Scheme $($Catalog.ProvisioningSchemeID)"
 					OutputWarning $txt
 				}
-				
-				<#
-				ProvisioningSchemeName : JCW-OnPrem-Win10
-				Date                   : 10/5/2021 10:36:59 AM
-				MasterImageVM          : XDHyp:\HostingUnits\WebstersLab\CVD-CC-BUILD-05102021-1718.vm\CVD-CC-BUILD-05102021-1732.snapshot
-				MasterImageNote        :
-				FunctionalLevel        : L7_30
-				ImageStatus            : Current
-				#>
-				
-				#Additional Data - added in 3.35
-				Write-Verbose "$(Get-Date -Format G): `t`t`tAdding catalog additional data (if any)"
-				
-				#The AdditionalData property is a hashtable and is neither null nor empty. 
-				#If there is nothing in the hashtable, the count value is 0
-				try
+			}
+			Else
+			{
+				#oops shouldn't be here
+			}
+		}
+		
+		#added in 3.39
+		#is there a reboot schedule configured for this catalog
+		#new for 2212
+		If($Script:CVADSiteVersion -ge "7.36")
+		{
+			#to prevent the "Get-BrokerCatalogRebootSchedule : Object does not exist" error
+			#get all the reboot schedules
+			
+			$CatalogRebootSchedules = Get-BrokerCatalogRebootSchedule @CVADParams1
+			
+			If($? -and $Null -ne $CatalogRebootSchedules)
+			{
+				#see if the $CatalogRebootSchedules object contains this catalog's Uid
+				If($CatalogRebootSchedules.CatalogUid -Contains $Catalog.Uid)
 				{
-					If(Test-Path $Image.MasterImageVM 4>$Null)
-					{
-						$TmpData = Get-Item $Image.MasterImageVM -ea 0 4>$Null
-
-						If($? -and (validObject $TmpData AdditionalData))
-						{
-							$AdditionalData = $TmpData.AdditionalData
-						}
-						Else
-						{
-							$AdditionalData = @{}
-						}
-					}
-					Else
-					{
-						$AdditionalData = @{}
-					}
-				}
-				
-				catch
-				{
-					$AdditionalData = @{}
-				}
-				
-				If($AdditionalData.Count -eq 0)
-				{
-					#There is no additional data, so nothing to do
-				}
-				ElseIf($AdditionalData.Count -gt 0)
-				{
-					If($MSWord -or $PDF)
-					{
-						WriteWordLine 4 0 "Additional Data"
-						$AdditionalDataWordTable = @()
-					}
-					If($Text)
-					{
-						Line 1 "Additional Data"
-
-						Line 2 'Additional Property Name                  Value                    '
-						Line 2 '==================================================================='
-						#       ServiceOfferingWithTemporaryDiskSizeInMbSS1234567890123456789012345
-						#       1234567890123456789012345678901234567890
-					}
-					If($HTML)
-					{
-						WriteHTMLLine 4 0 "Additional Data"
-						$rowdata = @()
-					}
-
-					ForEach($Item in $AdditionalData.Keys)
-					{
-						If($MSWord -or $PDF)
-						{
-							$AdditionalDataWordTable += @{ 
-								PropertyName  = $Item;
-								PropertyValue = $AdditionalData.$Item;
-							}
-						}
-						If($Text)
-						{
-							Line 2 ( "{0,-40}  {1,-25}" -f $Item, $AdditionalData.$Item )
-						}
-						If($HTML)
-						{
-							$rowdata += @(,(
-								$Item,$htmlwhite,
-								$AdditionalData.$Item,$htmlwhite)
-							)
-						}
-					}
+					$CatalogRebootSchedule = $CatalogRebootSchedules | Where-Object {$_.CatalogUid -eq $Catalog.Uid}
+					<#
+						Active                : False
+						CatalogName           : Win10 Random
+						CatalogUid            : 1
+						Description           :
+						Enabled               : True
+						MaxOvertimeStartMins  : 0
+						Name                  : Update reboot
+						RebootDuration        : 240 [minutes]
+						StartDate             : 2022-02-03
+						StartTime             : 01:00:00
+						Uid                   : 1
+						WarningDuration       : 10 [minutes]
+						WarningMessage        : Save your work
+						WarningRepeatInterval : 0 [minutes]
+						WarningTitle          : WARNING: Reboot pending
+					#>
 					
 					If($MSWord -or $PDF)
 					{
-						If($AdditionalDataWordTable.Count -eq 0)
-						{
-							$AdditionalDataWordTable += @{ 
-								PropertyName  = "None found";
-								PropertyValue = "";
-							}
-						}
-						
-						$Table = AddWordTable -Hashtable $AdditionalDataWordTable `
-						-Columns PropertyName, PropertyValue `
-						-Headers "Additional Property Name", "Value" `
+						WriteWordLine 4 0 "Catalog Reboot Schedule"
+						[System.Collections.Hashtable[]] $CatalogInformation = @()
+						$CatalogInformation += @{Data = "Reboot schedule name"; Value = $CatalogRebootSchedule.Name; }
+						$CatalogInformation += @{Data = "Description"; Value = $CatalogRebootSchedule.Description; }
+						$CatalogInformation += @{Data = "Active"; Value = $CatalogRebootSchedule.Active.ToString(); }
+						$CatalogInformation += @{Data = "Enabled"; Value = $CatalogRebootSchedule.Enabled.ToString(); }
+						$CatalogInformation += @{Data = "Max Overtime Start Minutes"; Value = $CatalogRebootSchedule.MaxOvertimeStartMins.ToString(); }
+						$CatalogInformation += @{Data = "Reboot duration in Minutes"; Value = $CatalogRebootSchedule.RebootDuration.ToString(); }
+						$CatalogInformation += @{Data = "Start Date"; Value = $CatalogRebootSchedule.StartDate.ToString(); }
+						$CatalogInformation += @{Data = "Start Time"; Value = $CatalogRebootSchedule.StartTime.ToString(); }
+						$CatalogInformation += @{Data = "Warning Duration in Minutes"; Value = $CatalogRebootSchedule.WarningDuration.ToString(); }
+						$CatalogInformation += @{Data = "Warning Message"; Value = $CatalogRebootSchedule.WarningMessage; }
+						$CatalogInformation += @{Data = "Warning Repeat Interval in Minutes"; Value = $CatalogRebootSchedule.WarningRepeatInterval.ToString(); }
+						$CatalogInformation += @{Data = "Warning Title"; Value = $CatalogRebootSchedule.WarningTitle; }
+				
+						$Table = AddWordTable -Hashtable $CatalogInformation `
+						-Columns Data,Value `
+						-List `
 						-Format $wdTableGrid `
-						-AutoFit $wdAutoFitContent;
+						-AutoFit $wdAutoFitFixed;
 
-						SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+						SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+						$Table.Columns.Item(1).Width = 225;
+						$Table.Columns.Item(2).Width = 275;
 
 						$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
 
@@ -8616,28 +8743,45 @@ Function OutputMachines
 					}
 					If($Text)
 					{
+						Line 1 "Catalog Reboot Schedule"
+						Line 2 "Reboot schedule name`t`t`t: " $CatalogRebootSchedule.Name
+						Line 2 "Description`t`t`t`t: " $CatalogRebootSchedule.Description
+						Line 2 "Active`t`t`t`t`t: " $CatalogRebootSchedule.Active.ToString()
+						Line 2 "Enabled`t`t`t`t`t: " $CatalogRebootSchedule.Enabled.ToString()
+						Line 2 "Max Overtime Start Minutes`t`t: " $CatalogRebootSchedule.MaxOvertimeStartMins.ToString()
+						Line 2 "Reboot duration in Minutes`t`t: " $CatalogRebootSchedule.RebootDuration.ToString()
+						Line 2 "Start Date`t`t`t`t: " $CatalogRebootSchedule.StartDate.ToString()
+						Line 2 "Start Time`t`t`t`t: " $CatalogRebootSchedule.StartTime.ToString()
+						Line 2 "Warning Duration in Minutes`t`t: " $CatalogRebootSchedule.WarningDuration.ToString()
+						Line 2 "Warning Message`t`t`t`t: " $CatalogRebootSchedule.WarningMessage
+						Line 2 "Warning Repeat Interval in Minutes`t: " $CatalogRebootSchedule.WarningRepeatInterval.ToString()
+						Line 2 "Warning Title`t`t`t`t: " $CatalogRebootSchedule.WarningTitle
 						Line 0 ""
 					}
 					If($HTML)
 					{
-						$columnHeaders = @(
-							'Additional Property Name',($global:htmlsb),
-							'Value',($global:htmlsb)
-						)
+						WriteHTMLLine 4 0 "Catalog Reboot Schedule"
+						$rowdata = @()
+						$columnHeaders = @("Description",($global:htmlsb),$Catalog.Description,$htmlwhite)
+						$rowdata += @(,( "Reboot schedule name",($global:htmlsb), $CatalogRebootSchedule.Name,$htmlwhite))
+						$rowdata += @(,( "Description",($global:htmlsb), $CatalogRebootSchedule.Description,$htmlwhite))
+						$rowdata += @(,( "Active",($global:htmlsb), $CatalogRebootSchedule.Active.ToString(),$htmlwhite))
+						$rowdata += @(,( "Enabled",($global:htmlsb), $CatalogRebootSchedule.Enabled.ToString(),$htmlwhite))
+						$rowdata += @(,( "Max Overtime Start Minutes",($global:htmlsb), $CatalogRebootSchedule.MaxOvertimeStartMins.ToString(),$htmlwhite))
+						$rowdata += @(,( "Reboot duration in Minutes",($global:htmlsb), $CatalogRebootSchedule.RebootDuration.ToString(),$htmlwhite))
+						$rowdata += @(,( "Start Date",($global:htmlsb), $CatalogRebootSchedule.StartDate.ToString(),$htmlwhite))
+						$rowdata += @(,( "Start Time",($global:htmlsb), $CatalogRebootSchedule.StartTime.ToString(),$htmlwhite))
+						$rowdata += @(,( "Warning Duration in Minutes",($global:htmlsb), $CatalogRebootSchedule.WarningDuration.ToString(),$htmlwhite))
+						$rowdata += @(,( "Warning Message",($global:htmlsb), $CatalogRebootSchedule.WarningMessage,$htmlwhite))
+						$rowdata += @(,( "Warning Repeat Interval in Minutes",($global:htmlsb), $CatalogRebootSchedule.WarningRepeatInterval.ToString(),$htmlwhite))
+						$rowdata += @(,( "Warning Title",($global:htmlsb), $CatalogRebootSchedule.WarningTitle,$htmlwhite))
 
 						$msg = ""
-						FormatHTMLTable $msg "auto" -rowArray $rowdata -columnArray $columnHeaders
+						$columnWidths = @("200","500")
+						FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "700"
 						WriteHTMLLine 0 0 ""
 					}
 				}
-				Else
-				{
-					#Could not retrieve additional data, so nothing to do
-				}
-			}
-			Else
-			{
-				#oops shouldn't be here
 			}
 		}
 
@@ -9221,6 +9365,16 @@ Function OutputMachineDetails
 		$xWillShutdownAfterUse = "No"
 	}
 
+	#added in 3.39 to fix the missing $WillShutdownAfterUseReason variable
+	Switch($Machine.WillShutdownAfterUseReason)
+	{
+		"None"						{$WillShutdownAfterUseReason = "Machine will not shutdown after use"; Break}
+		"ResetDiskImage"			{$WillShutdownAfterUseReason = "Machine will shutdown after use to reset its disk image"; Break}
+		"ScheduledNaturalReboot"	{$WillShutdownAfterUseReason = "Machine will shutdown after use as part of the scheduled natural reboot process"; Break}
+		"OnDemandNaturalReboot"		{$WillShutdownAfterUseReason = "Machine will shutdown after use as part of an on-demand natural reboot process."; Break}
+		Default						{$WillShutdownAfterUseReason = "Unable to determine the value of WillShutdownAfterUseReason: $($Machine.WillShutdownAfterUseReason)"; Break}
+	}
+	
 	$xSessionSmartAccessTags = @()
 	ForEach($value in $Machine.SessionSmartAccessTags)
 	{
@@ -34197,6 +34351,9 @@ Function GetRolePermissions
 			"AppLib_AddPackage"											{$Results.Add("Add App-V Application Libraries and Packages", "App-V")}
 			"AppLib_IsolationGroup_Create"								{$Results.Add("Create App-V Isolation Group", "App-V")}
 			"AppLib_IsolationGroup_Remove"								{$Results.Add("Remove App-V Isolation Groups", "App-V")}
+			"AppLib_PackageDiscovery_Create"							{$Results.Add("Create Application Package Discovery Sessions", "App-V")} #new in 2212
+			"AppLib_PackageDiscoveryProfile_Create"						{$Results.Add("Create Application Package Discovery Profiles", "App-V")} #new in 2212
+			"AppLib_PackageDiscoveryProfile_Remove"						{$Results.Add("Remove Application Package Discovery Profiles", "App-V")} #new in 2212
 			"AppLib_Read"												{$Results.Add("Read App-V Application Libraries and Packages", "App-V")}
 			"AppLib_RemoveApplication"									{$Results.Add("Remove App-V applications", "App-V")}
 			"AppLib_RemovePackage"										{$Results.Add("Remove App-V Application Libraries and Packages", "App-V")}
@@ -34230,15 +34387,19 @@ Function GetRolePermissions
 			"DesktopGroup_ChangeTags"									{$Results.Add("Edit Delivery Group tags", "Delivery Groups")}
 			"DesktopGroup_ChangeUserAssignment"							{$Results.Add("Change users assigned to a desktop", "Delivery Groups")}
 			"DesktopGroup_Create"										{$Results.Add("Create Delivery Group", "Delivery Groups")}
+			"DesktopGroup_CreateFolder"									{$Results.Add("Create Delivery Group Folder", "Delivery Groups")} #new in 2212
 			"DesktopGroup_Delete"										{$Results.Add("Delete Delivery Group", "Delivery Groups")}
+			"DesktopGroup_EditFolder"									{$Results.Add("Edit Delivery Group Folder", "Delivery Groups")} #new in 2212
 			"DesktopGroup_EditProperties"								{$Results.Add("Edit Delivery Group Properties", "Delivery Groups")}
 			"DesktopGroup_Machine_ChangeTags"							{$Results.Add("Edit Delivery Group machine tags", "Delivery Groups")}
+			"DesktopGroup_MoveFolder"									{$Results.Add("Move Delivery Group Folder", "Delivery Groups")} #new in 2212
 			"DesktopGroup_PowerOperations_RDS"							{$Results.Add("Perform power operations on Windows Server machines via Delivery Group membership", "Delivery Groups")}
 			"DesktopGroup_PowerOperations_VDI"							{$Results.Add("Perform power operations on Windows Desktop machines via Delivery Group membership", "Delivery Groups")}
 			"DesktopGroup_Read"											{$Results.Add("View Delivery Groups", "Delivery Groups")}
 			"DesktopGroup_RemoveApplication"							{$Results.Add("Remove Application from Delivery Group", "Delivery Groups")}
 			"DesktopGroup_RemoveApplicationGroup"						{$Results.Add("Remove Application Group from Delivery Group", "Delivery Groups")}
 			"DesktopGroup_RemoveDesktop"								{$Results.Add("Remove Desktop from Delivery Group", "Delivery Groups")}
+			"DesktopGroup_RemoveFolder"									{$Results.Add("Remove Delivery Group Folder", "Delivery Groups")} #new in 2212
 			"DesktopGroup_RemoveScope"									{$Results.Add("Remove Delivery Group from Scope", "Delivery Groups")}
 			"DesktopGroup_SessionManagement"							{$Results.Add("Perform session management on machines via Delivery Group membership", "Delivery Groups")}
 			"Machine_ChangeTagsBase"									{$Results.Add("Edit machine tags", "Delivery Groups")}
@@ -34316,13 +34477,17 @@ Function GetRolePermissions
 			"Catalog_ChangeUserAssignment"								{$Results.Add("Change users assigned to a machine", "Machine Catalogs")}
 			"Catalog_ConsumeMachines"									{$Results.Add("Allow machines to be consumed by a Delivery Group", "Machine Catalogs")}
 			"Catalog_Create"											{$Results.Add("Create Machine Catalog", "Machine Catalogs")}
+			"Catalog_CreateFolder"										{$Results.Add("Create Machine Catalog Folder", "Machine Catalogs")} #new in 2212
 			"Catalog_Delete"											{$Results.Add("Delete Machine Catalog", "Machine Catalogs")}
+			"Catalog_EditFolder"										{$Results.Add("Edit Machine Catalog Folder", "Machine Catalogs")} #new in 2212
 			"Catalog_EditProperties"									{$Results.Add("Edit Machine Catalog Properties", "Machine Catalogs")}
 			"Catalog_Manage_ChangeTags"									{$Results.Add("Edit Catalog machine tags", "Machine Catalogs")}
 			"Catalog_ManageAccounts"									{$Results.Add("Manage Active Directory Accounts", "Machine Catalogs")}
+			"Catalog_MoveFolder"										{$Results.Add("Move Machine Catalog Folder", "Machine Catalogs")} #new in 2212
 			"Catalog_PowerOperations_RDS"								{$Results.Add("Perform power operations on Windows Server machines via Machine Catalog membership", "Machine Catalogs")}
 			"Catalog_PowerOperations_VDI"								{$Results.Add("Perform power operations on Windows Desktop machines via Machine Catalog membership", "Machine Catalogs")}
 			"Catalog_Read"												{$Results.Add("View Machine Catalogs", "Machine Catalogs")}
+			"Catalog_RemoveFolder"										{$Results.Add("Remove Machine Catalog Folder", "Machine Catalogs")} #new in 2212
 			"Catalog_RemoveMachine"										{$Results.Add("Remove Machines from Machine Catalog", "Machine Catalogs")}
 			"Catalog_RemoveScope"										{$Results.Add("Remove Machine Catalog from Scope", "Machine Catalogs")}
 			"Catalog_SessionManagement"									{$Results.Add("Perform session management on machines via Machine Catalog membership", "Machine Catalogs")}
@@ -34349,6 +34514,14 @@ Function GetRolePermissions
 
 			"Policies_Manage"											{$Results.Add("Manage Policies", "Policies")}
 			"Policies_Read"												{$Results.Add("View Policies", "Policies")}
+
+			"PolicySets_AddScope"										{$Results.Add("Add Policy Set to Scope", "Policy Sets")} #new in 2212
+			"PolicySets_Manage"											{$Results.Add("Manage Policy Sets", "Policy Sets")} #new in 2212
+			"PolicySets_Read"											{$Results.Add("View Policy Sets", "Policy Sets")} #new in 2212
+			"PolicySets_RemoveScope"									{$Results.Add("Remove Policy Set from Scope", "Policy Sets")} #new in 2212
+
+			"Setting_Edit"												{$Results.Add("Edit Settings", "Settings")} #new in 2212
+			"Setting_Read"												{$Results.Add("View Settings", "Settings")} #new in 2212
 
 			"Storefront_Create"											{$Results.Add("Create a new StoreFront definition", "StoreFronts")}
 			"Storefront_Delete"											{$Results.Add("Delete a StoreFront definition", "StoreFronts")}
@@ -38089,6 +38262,8 @@ Function ProcessScriptSetup
 			$CVADSiteVersionReal = "Unknown"
 			Switch ($CVADSiteVersion)
 			{
+				"7.36"	{$CVADSiteVersionReal = "CVAD 2212"; Break}
+				"7.35"	{$CVADSiteVersionReal = "CVAD 2209"; Break}
 				"7.34"	{$CVADSiteVersionReal = "CVAD 2206"; Break}
 				"7.33"	{$CVADSiteVersionReal = "CVAD 2203"; Break}
 				"7.32"	{$CVADSiteVersionReal = "CVAD 2112"; Break}
@@ -38302,6 +38477,8 @@ Script cannot continue
 	$Script:CVADSiteVersionReal = "Unknown"
 	Switch ($Script:CVADSiteVersion)
 	{
+		"7.36"	{$Script:CVADSiteVersionReal = "CVAD 2212"; Break}
+		"7.35"	{$Script:CVADSiteVersionReal = "CVAD 2209"; Break}
 		"7.34"	{$Script:CVADSiteVersionReal = "CVAD 2206"; Break}
 		"7.33"	{$Script:CVADSiteVersionReal = "CVAD 2203"; Break}
 		"7.32"	{$Script:CVADSiteVersionReal = "CVAD 2112"; Break}

--- a/CVAD_Inventory_V3_ReadMe.rtf
+++ b/CVAD_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -78,30 +78,30 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
-\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid225408\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid859907\rsid928241\rsid1255483\rsid1260987\rsid1575696
-\rsid1600787\rsid1654655\rsid1732294\rsid1787124\rsid1857973\rsid2054605\rsid2163600\rsid2191181\rsid2195246\rsid2236948\rsid2243781\rsid2299261\rsid2299277\rsid2517006\rsid2579094\rsid2584542\rsid2653562\rsid2847190\rsid2902416\rsid2978753\rsid3097678
-\rsid3151791\rsid3300860\rsid3361471\rsid3430394\rsid3505396\rsid3542051\rsid3550749\rsid3760385\rsid3761251\rsid3830441\rsid4138244\rsid4149699\rsid4204758\rsid4213396\rsid4222850\rsid4357927\rsid4462158\rsid4522193\rsid4740061\rsid4745200\rsid4879052
-\rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5207971\rsid5209339\rsid5267713\rsid5339870\rsid5460787\rsid5573752\rsid5588803\rsid5703879\rsid5728664\rsid5847035\rsid6053627\rsid6054960\rsid6058160\rsid6186463\rsid6258287\rsid6316284\rsid6565250
-\rsid6635878\rsid6637724\rsid6819877\rsid6947370\rsid6966385\rsid7091148\rsid7097660\rsid7100238\rsid7233217\rsid7432229\rsid7560681\rsid7733837\rsid7755955\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828\rsid8662784
-\rsid8790405\rsid8876191\rsid8913570\rsid9047498\rsid9112866\rsid9338186\rsid9376723\rsid9443430\rsid9503154\rsid9520485\rsid9532820\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10303296\rsid10315109\rsid10488541
+\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid225408\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid859907\rsid928241\rsid986832\rsid1255483\rsid1260987
+\rsid1575696\rsid1600787\rsid1654655\rsid1732294\rsid1787124\rsid1857973\rsid2054605\rsid2163600\rsid2191181\rsid2195246\rsid2236948\rsid2243781\rsid2299261\rsid2299277\rsid2517006\rsid2579094\rsid2584542\rsid2653562\rsid2847190\rsid2902416\rsid2978753
+\rsid3097678\rsid3151791\rsid3300860\rsid3361471\rsid3430394\rsid3505396\rsid3542051\rsid3550749\rsid3760385\rsid3761251\rsid3830441\rsid4138244\rsid4149699\rsid4204758\rsid4213396\rsid4222850\rsid4357927\rsid4462158\rsid4522193\rsid4740061\rsid4745200
+\rsid4879052\rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5207971\rsid5209339\rsid5267713\rsid5339870\rsid5460787\rsid5573752\rsid5588803\rsid5703879\rsid5728664\rsid5847035\rsid6053627\rsid6054960\rsid6058160\rsid6186463\rsid6258287\rsid6316284
+\rsid6565250\rsid6635878\rsid6637724\rsid6819877\rsid6947370\rsid6966385\rsid7091148\rsid7097660\rsid7100238\rsid7233217\rsid7432229\rsid7560681\rsid7733837\rsid7755955\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828
+\rsid8662784\rsid8790405\rsid8876191\rsid8913570\rsid9047498\rsid9112866\rsid9338186\rsid9376723\rsid9443430\rsid9503154\rsid9520485\rsid9532820\rsid9639341\rsid9708402\rsid9765064\rsid9905429\rsid9974690\rsid9986361\rsid10303296\rsid10315109\rsid10488541
 \rsid10491303\rsid10578344\rsid10580546\rsid10775101\rsid10841649\rsid10900280\rsid10963467\rsid10967884\rsid11041950\rsid11161434\rsid11227030\rsid11345509\rsid11488686\rsid11605034\rsid11823514\rsid11884716\rsid12258164\rsid12271374\rsid12272355
-\rsid12277571\rsid12346830\rsid12353294\rsid12403800\rsid12467537\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13270439\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13704504\rsid13767035
-\rsid13853169\rsid13966007\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14362273\rsid14382587\rsid14577313\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid14964124\rsid15346731\rsid15405088
-\rsid15428007\rsid15548549\rsid15613047\rsid15623927\rsid15667239\rsid15678052\rsid15692337\rsid15739384\rsid15797907\rsid15802422\rsid15873118\rsid15877015\rsid15948729\rsid16017241\rsid16017738\rsid16085929\rsid16154053\rsid16203271\rsid16207041
-\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420\rsid16529279\rsid16597410\rsid16669189\rsid16671705\rsid16713983}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1
-\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2022\mo10\dy2\hr16\min51}{\version132}{\edmins11958}{\nofpages29}{\nofwords8900}{\nofchars50731}{\nofcharsws59512}{\vern57}}{\*\userprops 
-{\propname GrammarlyDocumentId}\proptype30{\staticval 5579c832d1ee4e8e3510172055c7e3af8a0e5c2851bea29f74fe6c54ae6c5731}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid12277571\rsid12346830\rsid12353294\rsid12403800\rsid12467537\rsid12523992\rsid12541957\rsid12602409\rsid12732682\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13270439\rsid13401205\rsid13437246\rsid13460658\rsid13662136\rsid13704504
+\rsid13767035\rsid13853169\rsid13966007\rsid13976227\rsid13987238\rsid14097372\rsid14169246\rsid14294352\rsid14362273\rsid14382587\rsid14577313\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid14964124\rsid15346731
+\rsid15405088\rsid15428007\rsid15548549\rsid15613047\rsid15623927\rsid15667239\rsid15678052\rsid15692337\rsid15739384\rsid15797907\rsid15802422\rsid15873118\rsid15877015\rsid15948729\rsid16017241\rsid16017738\rsid16085929\rsid16154053\rsid16203271
+\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420\rsid16529279\rsid16597410\rsid16669189\rsid16671705\rsid16713983}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0
+\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2023\mo1\dy6\hr6\min32}{\version133}{\edmins11959}{\nofpages29}{\nofwords8900}{\nofchars50731}{\nofcharsws59512}{\vern61}}
+{\*\userprops {\propname GrammarlyDocumentId}\proptype30{\staticval 5579c832d1ee4e8e3510172055c7e3af8a0e5c2851bea29f74fe6c54ae6c5731}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBcaWtQA1Kfg3LQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5573752 \chftnsep 
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBSYGtQD5hHXjLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12732682 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5573752 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12732682 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5573752 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12732682 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5573752 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12732682 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid16203271 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 
@@ -314,7 +314,7 @@ ng>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7755955
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7755955 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/" }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7755955 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003b2}}
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003b200}}
 }{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid7755955 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
 \par 
@@ -326,13 +326,13 @@ ng>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7755955
 ix-cloud-citrix-virtual-apps-and-desktops-service/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7755955 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be6000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
 64002d0069006e0066006f002f006300690074007200690078002d0063006c006f00750064002d006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d0073006500720076006900630065002f000000795881
-f43b1d7f48af2c825dc485276300000000a5ab000394}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid7755955 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloa\hich\af2\dbch\af31505\loch\f2 
-ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
+f43b1d7f48af2c825dc485276300000000a5ab00039400}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid7755955 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downlo\hich\af2\dbch\af31505\loch\f2 
+ads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have at least Read access to the SQL
 \par \hich\af2\dbch\af31505\loch\f2     Server(s) that hold(s) the Citrix Site, Monitoring, and Logging databases.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     By defau\hich\af2\dbch\af31505\loch\f2 lt, only gives summary information for:
+\par \hich\af2\dbch\af31505\loch\f2     By defa\hich\af2\dbch\af31505\loch\f2 ult, only gives summary information for:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         App-V Publishing
 \par \hich\af2\dbch\af31505\loch\f2         Application Groups
@@ -343,7 +343,7 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Policies
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       StoreFront
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        StoreFront
 \par \hich\af2\dbch\af31505\loch\f2         Zones
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
@@ -469,21 +469,21 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on 360 registry keys to the Controller \hich\af2\dbch\af31505\loch\f2 section.
+\par \hich\af2\dbch\af31505\loch\f2         Adds informa\hich\af2\dbch\af31505\loch\f2 tion on 360 registry keys to the Controller section.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         *****Requires the script runs elevated*****
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
-\par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controller, to the report.
+\par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controlle\hich\af2\dbch\af31505\loch\f2 r, to the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is\hich\af2\dbch\af31505\loch\f2  disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -529,20 +529,20 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information on all desktops in all Desktop (Delivery) Groups.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate \hich\af2\dbch\af31505\loch\f2 an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very \hich\af2\dbch\af31505\loch\f2 long
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
 \par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
-\par \hich\af2\dbch\af31505\loch\f2         long report.
+\par \hich\af2\dbch\af31505\loch\f2         lon\hich\af2\dbch\af31505\loch\f2 g report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled b\hich\af2\dbch\af31505\loch\f2 y default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -642,26 +642,26 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information from the output document.
-\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This Switch is useful\hich\af2\dbch\af31505\loch\f2  in large AD environments, where there may be thousands
-\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Posi\hich\af2\dbch\af31505\loch\f2 tion?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information f\hich\af2\dbch\af31505\loch\f2 rom the output document.
+\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This Switch is useful in large AD environments, where there may be thousands
+\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabl\hich\af2\dbch\af31505\loch\f2 ed by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard\hich\af2\dbch\af31505\loch\f2  characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD-based policy information from the output document.
@@ -669,29 +669,29 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 has an alias of NP.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?           \hich\af2\dbch\af31505\loch\f2          named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoSessions [<S\hich\af2\dbch\af31505\loch\f2 witchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes Machine Catalog, Application and Hosting session data from the report.
+\par \hich\af2\dbch\af31505\loch\f2     -NoSessions [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes Machine Catalog, Application and Hosting session data from\hich\af2\dbch\af31505\loch\f2  the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the MaxDetails parameter does not change this setting.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an ali\hich\af2\dbch\af31505\loch\f2 as of NS.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NS.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParamet\hich\af2\dbch\af31505\loch\f2 er>]
+\par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD-based Policies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
@@ -699,23 +699,23 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies, and NoADPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoP\hich\af2\dbch\af31505\loch\f2 olicies are mutually exclusive and priority is given to NoPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This p\hich\af2\dbch\af31505\loch\f2 arameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StoreFront [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SF.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter has an alias of SF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -729,26 +729,26 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of VRK.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?     \hich\af2\dbch\af31505\loch\f2   false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
-\par \hich\af2\dbch\af31505\loch\f2         Processes one or more section\hich\af2\dbch\af31505\loch\f2 s of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
-\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications and Application Group Details)
+\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications and Application Group De\hich\af2\dbch\af31505\loch\f2 tails)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
 \par \hich\af2\dbch\af31505\loch\f2                 Catalogs (Machine Catalogs)
 \par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Controllers
+\par \hich\af2\dbch\af31505\loch\f2                 Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Groups (Delivery Groups)
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
 \par \hich\af2\dbch\af31505\loch\f2                 Licensing
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
-\par \hich\af2\dbch\af31505\loch\f2                 Policies
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Policies
 \par \hich\af2\dbch\af31505\loch\f2                 StoreFront
 \par \hich\af2\dbch\af31505\loch\f2                 Zones
 \par \hich\af2\dbch\af31505\loch\f2                 All
@@ -759,26 +759,26 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Notes:
 \par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Logging Switch to True.
-\par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies Swit\hich\af2\dbch\af31505\loch\f2 ch to True.
-\par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies Switch is used, the script will terminate.
+\par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies Switch to True.
+\par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and th\hich\af2\dbch\af31505\loch\f2 e NoPolicies Switch is used, the script will terminate.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipelin\hich\af2\dbch\af31505\loch\f2 e input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard chara\hich\af2\dbch\af31505\loch\f2 cters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2022, at 6PM is 2022\hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         The output filename will be ReportName_2022-06-01_1800.docx (or.pdf).
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2022, at 6PM is 2022-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         The output filename will be R\hich\af2\dbch\af31505\loch\f2 eportName_2022-06-01_1800.docx (or.pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?             \hich\af2\dbch\af31505\loch\f2        named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                \hich\af2\dbch\af31505\loch\f2 False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -791,24 +791,24 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_Appendix#_NameOfAppendix.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For example:
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documen\hich\af2\dbch\af31505\loch\f2 tation_AppendixA_VDARegistryItems.csv
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_Append\hich\af2\dbch\af31505\loch\f2 ixB_ControllerRegistryItems.csv
 \par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixD\hich\af2\dbch\af31505\loch\f2 _CitrixInstalledComponents.csv
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixE_Win\hich\af2\dbch\af31505\loch\f2 dowsInstalledComponents.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<\hich\af2\dbch\af31505\loch\f2 SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when th\hich\af2\dbch\af31505\loch\f2 e script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script runs.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed \hich\af2\dbch\af31505\loch\f2 in the same folder from where the script runs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
@@ -819,25 +819,25 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies t\hich\af2\dbch\af31505\loch\f2 he optional output folder to save the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?               \hich\af2\dbch\af31505\loch\f2      false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Lo\hich\af2\dbch\af31505\loch\f2 g [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Requi\hich\af2\dbch\af31505\loch\f2 red?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs i\hich\af2\dbch\af31505\loch\f2 nformation about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script runs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -850,23 +850,23 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the end of the report.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Outputs a footer section at the end of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has \hich\af2\dbch\af31505\loch\f2 an alias of RF.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of RF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Report Footer
 \par \hich\af2\dbch\af31505\loch\f2                 Report information:
 \par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release Date>
-\par \hich\af2\dbch\af31505\loch\f2                         Script version: <Script Version>
-\par \hich\af2\dbch\af31505\loch\f2                         Started on\hich\af2\dbch\af31505\loch\f2  <Date Time in Local Format>
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2                   Script version: <Script Version>
+\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local Format>
 \par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
-\par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by user <Username>
+\par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by us\hich\af2\dbch\af31505\loch\f2 er <Username>
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from the folder <Folder Name>
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Scri\hich\af2\dbch\af31505\loch\f2 pt Name and Script Release date are script-specific variables.
+\par \hich\af2\dbch\af31505\loch\f2         Script Name and Script Release date are script-specific variables.
 \par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a calculated value.
-\par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Domain Name is $env:USERDNSDOMAIN.
 \par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
 \par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variable.
 \par 
@@ -874,53 +874,53 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value      \hich\af2\dbch\af31505\loch\f2           False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead \hich\af2\dbch\af31505\loch\f2 of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly\hich\af2\dbch\af31505\loch\f2  5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page if\hich\af2\dbch\af31505\loch\f2  the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word\hich\af2\dbch\af31505\loch\f2  2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Ion (Dark) (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016\hich\af2\dbch\af31505\loch\f2 )
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSW\hich\af2\dbch\af31505\loch\f2 ORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charac\hich\af2\dbch\af31505\loch\f2 ters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeli\hich\af2\dbch\af31505\loch\f2 ne input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page if the Cover Page has the Email field.
@@ -931,24 +931,24 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page if the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page if the Cover Page has the F\hich\af2\dbch\af31505\loch\f2 ax field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax\hich\af2\dbch\af31505\loch\f2  field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of\hich\af2\dbch\af31505\loch\f2  CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -992,84 +992,84 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't \hich\af2\dbch\af31505\loch\f2 work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Aust\hich\af2\dbch\af31505\loch\f2 ere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010, but Subtitle/Subject & Author fields need moving
-\par \hich\af2\dbch\af31505\loch\f2                 after th\hich\af2\dbch\af31505\loch\f2 e title box is moved up)
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 after the title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 Banded\hich\af2\dbch\af31505\loch\f2  (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if yo\hich\af2\dbch\af31505\loch\f2 u like looking sideways)
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Facet \hich\af2\dbch\af31505\loch\f2 (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (W\hich\af2\dbch\af31505\loch\f2 ord 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs \hich\af2\dbch\af31505\loch\f2 to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point\hich\af2\dbch\af31505\loch\f2 )
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or\hich\af2\dbch\af31505\loch\f2  font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slic\hich\af2\dbch\af31505\loch\f2 e (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 20\hich\af2\dbch\af31505\loch\f2 10. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. \hich\af2\dbch\af31505\loch\f2 Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF outp\hich\af2\dbch\af31505\loch\f2 ut parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    fa\hich\af2\dbch\af31505\loch\f2 lse
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String\hich\af2\dbch\af31505\loch\f2 >
+\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the option\hich\af2\dbch\af31505\loch\f2 al email server to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <In\hich\af2\dbch\af31505\loch\f2 t32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildca\hich\af2\dbch\af31505\loch\f2 rd characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
@@ -1078,22 +1078,12 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required param\hich\af2\dbch\af31505\loch\f2 eter.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1101,33 +1091,42 @@ ds/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -To <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction,\hich\af2\dbch\af31505\loch\f2  ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 \hich\af2\dbch\af31505\loch\f2  HYPERLI\hich\af2\dbch\af31505\loch\f2 
-NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030074}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216
+}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None. You cannot pipe ob\hich\af2\dbch\af31505\loch\f2 jects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None. You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
-\par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, plain text, or HTML document.
+\par \hich\af2\dbch\af31505\loch\f2     This sc\hich\af2\dbch\af31505\loch\f2 ript creates a Word, PDF, plain text, or HTML document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: CVAD_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2236948 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid986832 \hich\af2\dbch\af31505\loch\f2 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT\hich\af2\dbch\af31505\loch\f2 : }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2236948 \hich\af2\dbch\af31505\loch\f2 October 2, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15548549\charrsid15548549 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid986832 \hich\af2\dbch\af31505\loch\f2 January 6, 2023}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1144,15 +1143,15 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Of\hich\af2\dbch\af31505\loch\f2 fice\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKE\hich\af2\dbch\af31505\loch\f2 Y_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the Username.
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Wo\hich\af2\dbch\af31505\loch\f2 rd report.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1160,7 +1159,7 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AdminAd\hich\af2\dbch\af31505\loch\f2 dress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
 \par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
@@ -1172,14 +1171,14 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF fi\hich\af2\dbch\af31505\loch\f2 le.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Compan\hich\af2\dbch\af31505\loch\f2 y Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the Username.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1189,7 +1188,7 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Text
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.p\hich\af2\dbch\af31505\loch\f2 s1 -Text
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Saves the document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1199,7 +1198,7 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -HTML
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 CVAD_Inventory_V3.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Saves the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1207,9 +1206,9 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXA\hich\af2\dbch\af31505\loch\f2 MPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -MachineCata\hich\af2\dbch\af31505\loch\f2 logs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1217,9 +1216,9 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 8 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inven\hich\af2\dbch\af31505\loch\f2 tory_V3.ps1 -DeliveryGroups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all desktops in all Desktop (Delivery)
 \par \hich\af2\dbch\af31505\loch\f2     Groups.
@@ -1232,21 +1231,21 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroupsUtilization -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization req\hich\af2\dbch\af31505\loch\f2 uires the use of MSWord or PDF.
+\par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requires the use of MSWord or PDF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report with utilization details for all Desktop (Delivery)
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word \hich\af2\dbch\af31505\loch\f2 report with utilization details for all Desktop (Delivery)
 \par \hich\af2\dbch\af31505\loch\f2     Groups.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Us\hich\af2\dbch\af31505\loch\f2 erInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the Username.
-\par \hich\af2\dbch\af31505\loch\f2     The comput\hich\af2\dbch\af31505\loch\f2 er running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1257,54 +1256,54 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Note: Using DeliveryGroupsUtilization requires the use of MSWord or PDF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with utilization details for all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a PDF report with u\hich\af2\dbch\af31505\loch\f2 tilization details for all Desktop (Delivery) Groups.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="C\hich\af2\dbch\af31505\loch\f2 arl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator fo\hich\af2\dbch\af31505\loch\f2 r the Username.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the Username.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- \hich\af2\dbch\af31505\loch\f2 EXAMPLE 11 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -DeliveryGroups -MachineCatalogs
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report wit\hich\af2\dbch\af31505\loch\f2 h full details for all machines in all Machine Catalogs and
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all machines in all Machine Catalogs and
 \par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML repo\hich\af2\dbch\af31505\loch\f2 rt with full details for all applications.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------------\hich\af2\dbch\af31505\loch\f2 ------------ EXAMPLE 13 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Policies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details for Policies.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report\hich\af2\dbch\af31505\loch\f2  with full details for Policies.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------------\hich\af2\dbch\af31505\loch\f2 -- EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -NoPolicies
 \par 
@@ -1318,7 +1317,7 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with no Citrix AD-based Policy informa\hich\af2\dbch\af31505\loch\f2 tion.
+\par \hich\af2\dbch\af31505\loch\f2     Create\hich\af2\dbch\af31505\loch\f2 s an HTML report with no Citrix AD-based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1326,9 +1325,9 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Policies -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -Policies -NoADPoli\hich\af2\dbch\af31505\loch\f2 cies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on S\hich\af2\dbch\af31505\loch\f2 ite policies created in Studio but
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report with full details on Site policies created in Studio but
 \par \hich\af2\dbch\af31505\loch\f2     no Citrix AD-based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1818,7 +1817,7 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAdd\hich\af2\dbch\af31505\loch\f2 ress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1826,7 +1825,7 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 44 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
-\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@doma\hich\af2\dbch\af31505\loch\f2 in.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
@@ -1834,23 +1833,23 @@ NK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \lt
 \par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From email
-\par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonym\hich\af2\dbch\af31505\loch\f2 ous.
+\par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15548549 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://\hich\af2\dbch\af31505\loch\f2 support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030056}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15548549 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google\hich\af2\dbch\af31505\loch\f2 .com/a/answer/176600?hl=en" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000320}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00032010}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "\hich\af2\dbch\af31505\loch\f2 Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, \hich\af2\dbch\af31505\loch\f2 you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
@@ -1858,7 +1857,7 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for th\hich\af2\dbch\af31505\loch\f2 e AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The compu\hich\af2\dbch\af31505\loch\f2 ter running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1875,15 +1874,15 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us\hich\af2\dbch\af31505\loch\f2 
-/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030039}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15548549\charrsid15548549 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-u\hich\af2\dbch\af31505\loch\f2 
+s/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15548549\charrsid15548549 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.pro\hich\af2\dbch\af31505\loch\f2 tection.outlook.com, sending
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.pr\hich\af2\dbch\af31505\loch\f2 otection.outlook.com, sending
 \par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
@@ -1899,7 +1898,7 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\CVAD_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the\hich\af2\dbch\af31505\loch\f2  email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     The script uses th\hich\af2\dbch\af31505\loch\f2 e email server smtp.office365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
@@ -2053,10 +2052,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e50000000000000000000000003079
-2b26a9d6d80103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000030792b26a9d6d801
-30792b26a9d6d80100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000030792b26a9d6
-d80130792b26a9d6d8010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000e0ff
+67e1ca21d90103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000e0ff67e1ca21d901
+e0ff67e1ca21d90100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000e0ff67e1ca21
+d901e0ff67e1ca21d9010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/CVAD_V3_Script_ChangeLog.txt
+++ b/CVAD_V3_Script_ChangeLog.txt
@@ -6,6 +6,36 @@
 
 # This script is based on the 2.36 script
 
+#Version 3.39 6-Jan-2023
+#	Added to Function OutputMachines, the Catalog's reboot schedule if one exists
+#		https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/install-configure/machine-catalogs-manage.html#update-the-catalog
+#	For Provisioning Custom Properties, added two Azure properties I hadn't noticed before:
+#		https://developer-docs.citrix.com/projects/citrix-virtual-apps-desktops-sdk/en/latest/MachineCreation/about_Prov_CustomProperties/
+#		PageFileDiskDriveLetterOverride
+#		StorageTypeAtShutdown
+#	In Function GetRolePermissions:
+#		Added new permissions
+#			AppLib_PackageDiscovery_Create
+#			AppLib_PackageDiscoveryProfile_Create
+#			AppLib_PackageDiscoveryProfile_Remove
+#			DesktopGroup_CreateFolder
+#			DesktopGroup_EditFolder
+#			DesktopGroup_MoveFolder
+#			DesktopGroup_RemoveFolder
+#			Catalog_CreateFolder
+#			Catalog_EditFolder
+#			Catalog_MoveFolder
+#			Catalog_RemoveFolder
+#			PolicySets_AddScope
+#           PolicySets_Manage
+#           PolicySets_Read
+#           PolicySets_RemoveScope
+#           Setting_Edit
+#			Setting_Read
+#	In Function OutputMachineDetails, fixed the missing $WillShutdownAfterUseReason variable
+#	In Function OutputMachines, fixed the misplaced code for image history and additional data
+#	Updated for CVAD 2209/7.35 and CVAD 2212/7.36
+
 #Version 3.38 2-Oct-2022
 #	Added Computer policy
 #		Profile Management\Advanced settings\Maximum number of VHDX disks for storing Outlook OST files


### PR DESCRIPTION
#Version 3.39 6-Jan-2023
#	Added to Function OutputMachines, the Catalog's reboot schedule if one exists 
#		https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/install-configure/machine-catalogs-manage.html#update-the-catalog 
#	For Provisioning Custom Properties, added two Azure properties I hadn't noticed before: 
#		https://developer-docs.citrix.com/projects/citrix-virtual-apps-desktops-sdk/en/latest/MachineCreation/about_Prov_CustomProperties/ 
#		PageFileDiskDriveLetterOverride
#		StorageTypeAtShutdown
#	In Function GetRolePermissions:
#		Added new permissions
#			AppLib_PackageDiscovery_Create
#			AppLib_PackageDiscoveryProfile_Create
#			AppLib_PackageDiscoveryProfile_Remove
#			DesktopGroup_CreateFolder
#			DesktopGroup_EditFolder
#			DesktopGroup_MoveFolder
#			DesktopGroup_RemoveFolder
#			Catalog_CreateFolder
#			Catalog_EditFolder
#			Catalog_MoveFolder
#			Catalog_RemoveFolder
#			PolicySets_AddScope
#           PolicySets_Manage
#           PolicySets_Read
#           PolicySets_RemoveScope
#           Setting_Edit
#			Setting_Read
#	In Function OutputMachineDetails, fixed the missing $WillShutdownAfterUseReason variable
#	In Function OutputMachines, fixed the misplaced code for image history and additional data
#	Updated for CVAD 2209/7.35 and CVAD 2212/7.36